### PR TITLE
Fixed CanShoot reporting false on weapon reload

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -901,12 +901,19 @@ bool CanHeadshot()
 
 bool CanShoot()
 {
-
-    float servertime, nextattack;
-
-    servertime = (float) (CE_INT(g_pLocalPlayer->entity, netvar.nTickBase)) *
-                 g_GlobalVars->interval_per_tick;
+  static float servertime, lastfire, nextattack;
+    
+  float currfire = CE_FLOAT(g_pLocalPlayer->weapon(), netvar.flLastFireTime);
+    
+  if (lastFire != currfire)
+  {
+    lastfire = currfire;
     nextattack = CE_FLOAT(g_pLocalPlayer->weapon(), netvar.flNextPrimaryAttack);
+  }
+
+    float servertime = (float) (CE_INT(g_pLocalPlayer->entity, netvar.nTickBase)) *
+                 g_GlobalVars->interval_per_tick;
+    
     return nextattack <= servertime;
 }
 


### PR DESCRIPTION
Should fix a big annoying bug which has existed for ages. where the aimbot will not shoot with silent aim when reloading because the nextprimaryattack netvar reports that the next attack is when the reload finishes, which is in the future. This can be remedied by only updating nextattack if we have fired the weapon. This works with 99% of weapons, except flamethrowers - for some reason this change makes canshoot always return true. You might also want to check for flamethrowers and use the traditional method for them. Also i'm not sure if this code even compiles since I don't have the bandwidth to clone your repo right now, but i'm sure if it doesn't it should be an easy fix.