### PR TITLE
Disable backtrack by default and add UI setting

### DIFF
--- a/data/menu.json
+++ b/data/menu.json
@@ -523,6 +523,13 @@
 			},
 			{
 				"type": "list",
+				"name": "Backtrack",
+				"list": [
+					"backtrack"
+				]
+			},
+			{
+				"type": "list",
 				"name": "Debug Settings",
 				"list": [
 					"enabled",

--- a/src/hacks/Backtrack.cpp
+++ b/src/hacks/Backtrack.cpp
@@ -10,7 +10,7 @@
 namespace hacks {
 namespace shared {
 namespace backtrack {
-CatVar enable(CV_SWITCH, "backtrack", "1", "Enable backtrack", "For legit play only as of right now.");
+CatVar enable(CV_SWITCH, "backtrack", "0", "Enable backtrack", "For legit play only as of right now.");
 BacktrackData headPositions[24][12];
 
 //=======================================================================

--- a/src/visual/menu/ncc/Menu.cpp
+++ b/src/visual/menu/ncc/Menu.cpp
@@ -718,6 +718,10 @@ static const std::string list_tf2 = R"(
 				"spyalert_interval"
 				"spyalert_warning"
 				]
+				"Backtrack" [
+				"Backtrack Menu"
+				"backtrack"
+				]
 				"Anti Cheat" [
 				"Anti Cheat Menu"
 				"ac_enabled"


### PR DESCRIPTION
I don't think backtrack should be enabled by default since it makes for a bad user experience in my opinion. For example: 
- It creates annoying dots that don't go away in some occasions
- It lags the game out if aimbot is used in conjunction with backtrack (?)
- There is no GUI option to disable it