### PR TITLE
Improve install script and readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,7 @@ and a lot of useful features, including
 # INSTALLATION
 
 ## Automatic: (Ubuntu based only)
-If you already downloaded the repo, simply run 
-* `install-all`
-
-Else simply run:
+Run in terminal:
 
 * `wget https://raw.githubusercontent.com/nullworks/cathook/master/install-all && bash install-all`
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,13 @@ and a lot of useful features, including
 
 # INSTALLATION
 
-## Automatic:
+## Automatic: (Ubuntu based only)
 If you already downloaded the repo, simply run 
 * `install-all`
 
 Else simply run:
 
-* `git clone --recursive https://github.com/nullworks/One-in-all-cathook-install/blob/master/install-all.git`
-and run it's install-all script.
+* `wget https://raw.githubusercontent.com/nullworks/cathook/master/install-all && bash install-all`
 
 ## Manual:
 You need CMake to build cathook, CMake should take care of dependencies

--- a/install-all
+++ b/install-all
@@ -25,5 +25,4 @@ git clone --recursive https://github.com/nullworks/simple-ipc.git;cd simple-ipc;
 #
 # Build cathook
 #
-
-mkdir build;cd build;cmake ..;make -j$(grep -c '^processor' /proc/cpuinfo);make data
+git clone --recursive https://github.com/nullworks/cathook.git;cd cathook;mkdir build;cd build;cmake ..;make -j$(grep -c '^processor' /proc/cpuinfo);make data

--- a/install-all
+++ b/install-all
@@ -2,7 +2,7 @@
 # Install base Dependencies
 #
 
-sudo apt update && sudo apt install build-essential gcc-multilib g++-multilib software-properties-common -y && sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y && sudo apt update && sudo apt install gcc-snapshot g++-6-multilib gcc-6 g++-6 -y && sudo apt update && sudo apt install git libssl-dev:i386 libboost-all-dev libc6-dev:i386 gdb libsdl2-dev libglew-dev:i386 libglew-dev libfreetype6-dev libfreetype6-dev:i386 cmake libpng-dev libssl-dev cmake gcc-multilib g++-multilib -y
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y && sudo apt update && sudo apt install build-essential gcc-multilib g++-multilib software-properties-common gcc-snapshot g++-6-multilib gcc-6 g++-6 libssl-dev:i386 libboost-all-dev libc6-dev:i386 gdb libsdl2-dev libglew-dev:i386 libglew-dev libfreetype6-dev libfreetype6-dev:i386 cmake libpng-dev libssl-dev cmake gcc-multilib g++-multilib -y
 
 #
 # Install libglez


### PR DESCRIPTION
**README.md**
1. Inform user that it only works for Ubuntu (or Ubuntu based). (Maybe debian?)
2. Use wget to download the file from the main cathook repo. We don't need to maintain a secondary repo if we can avoid it.
3. The file is however not executable. We need to use bash to execute it.
4. Removed "already downloaded repo" method
**install-all**
4. Don't run apt update 3 times if it can be avoided.
5. Clone cathook since we don't clone the entire repo anymore.