### PR TITLE
Streamline cathook update process

### DIFF
--- a/install-all
+++ b/install-all
@@ -8,6 +8,8 @@ sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y && sudo apt update && sud
 # Install libglez
 #
 
+mkdir cathook; cd cathook
+
 git clone --recursive https://github.com/nullworks/libglez.git;cd libglez;mkdir build;cd build;cmake ..;make;sudo make install;cd ..;cd ..
 
 #
@@ -26,4 +28,11 @@ git clone --recursive https://github.com/nullworks/simple-ipc.git;cd simple-ipc;
 # Build cathook
 #
 
-git clone --recursive https://github.com/nullworks/cathook.git;cd cathook;mkdir build;cd build;cmake ..;make -j$(grep -c '^processor' /proc/cpuinfo); sudo make data
+git clone --recursive https://github.com/nullworks/cathook.git;cd cathook;mkdir build;cd build;cmake ..;make -j$(grep -c '^processor' /proc/cpuinfo); sudo make data; cd ..; cd ..
+
+#
+# Do post installation stuff
+#
+
+cp -a -u ./cathook/tools/. ./
+rm ./README

--- a/install-all
+++ b/install-all
@@ -36,3 +36,4 @@ git clone --recursive https://github.com/nullworks/cathook.git;cd cathook;mkdir 
 
 cp -a -u ./cathook/tools/. ./
 rm ./README
+cd ..; rm install-all

--- a/tools/README
+++ b/tools/README
@@ -1,0 +1,1 @@
+These files are not intended to be run from this folder.

--- a/tools/attach
+++ b/tools/attach
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cd cathook
+sudo bash attach

--- a/tools/update
+++ b/tools/update
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+cd cathook
+
+update()
+{
+    git fetch >update.log
+    if ! git pull origin $(git rev-parse --abbrev-ref HEAD) >>update.log; then
+        $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
+        exit
+    fi
+    if ! git submodule update --remote --recursive >>update.log; then
+        $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
+        exit
+    fi
+}
+
+update
+
+cd build; cmake ..; make; cd ..; cd ..
+
+cp -a -u ./cathook/tools/. ./; rm ./README
+

--- a/tools/update
+++ b/tools/update
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 rm ./updater.sh
-wget https://raw.githubusercontent.com/TotallyNotElite/cathook/testingbranch01/tools/updater.sh
+wget https://raw.githubusercontent.com/nullworks/cathook/master/tools/updater.sh
 updater() {
   source updater.sh
 }

--- a/tools/update
+++ b/tools/update
@@ -1,27 +1,7 @@
 #!/usr/bin/env bash
-rm ./updater
-wget https://raw.githubusercontent.com/TotallyNotElite/cathook/testingbranch01/tools/updater
-bash updater
-
-: '
-cd cathook
-
-update()
-{
-    git fetch >update.log
-    if ! git pull origin $(git rev-parse --abbrev-ref HEAD) >>update.log; then
-        $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
-        exit
-    fi
-    if ! git submodule update --remote --recursive >>update.log; then
-        $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
-        exit
-    fi
+rm ./updater.sh
+wget https://raw.githubusercontent.com/TotallyNotElite/cathook/testingbranch01/tools/updater.sh
+updater() {
+  source updater.sh
 }
-
-update
-
-cd build; cmake ..; make; cd ..; cd ..
-
-cp -a -u ./cathook/tools/. ./; rm ./README
-'
+updater

--- a/tools/update
+++ b/tools/update
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
+rm ./updater
+wget https://raw.githubusercontent.com/TotallyNotElite/cathook/testingbranch01/tools/updater
+bash updater
 
+: '
 cd cathook
 
 update()
@@ -20,4 +24,4 @@ update
 cd build; cmake ..; make; cd ..; cd ..
 
 cp -a -u ./cathook/tools/. ./; rm ./README
-
+'

--- a/tools/updater
+++ b/tools/updater
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+cd cathook
+
+
+git fetch >update.log
+if ! git pull origin $(git rev-parse --abbrev-ref HEAD) >>update.log; then
+    $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
+    exit
+fi
+if ! git submodule update --remote --recursive >>update.log; then
+    $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
+    exit
+fi
+}
+
+cd build; cmake ..; make; cd ..; cd ..
+
+cp -a -u ./cathook/tools/. ./; rm ./README; rm ./updater
+

--- a/tools/updater
+++ b/tools/updater
@@ -51,4 +51,5 @@ cd build; cmake ..; make; cd ..; cd ..
 
 
 cp -a -u ./cathook/tools/. ./; rm ./README; rm ./updater
-
+exit
+#Important! Otherwise you will run into weird bash issues after copying files

--- a/tools/updater
+++ b/tools/updater
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
+sudo echo Elevated
 
-cd cathook
-
-
+cd libglez
 git fetch >update.log
 if ! git pull origin $(git rev-parse --abbrev-ref HEAD) >>update.log; then
     $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
@@ -12,9 +11,44 @@ if ! git submodule update --remote --recursive >>update.log; then
     $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
     exit
 fi
-}
+cd build; cmake ..; make;sudo make install;cd ..; cd ..
 
+cd libxoverlay
+git fetch >update.log
+if ! git pull origin $(git rev-parse --abbrev-ref HEAD) >>update.log; then
+    $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
+    exit
+fi
+if ! git submodule update --remote --recursive >>update.log; then
+    $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
+    exit
+fi
+cd build; cmake ..; make;sudo make install;cd ..; cd ..
+
+cd simple-ipc
+git fetch >update.log
+if ! git pull origin $(git rev-parse --abbrev-ref HEAD) >>update.log; then
+    $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
+    exit
+fi
+if ! git submodule update --remote --recursive >>update.log; then
+    $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
+    exit
+fi
+cd build; cmake ..; make;sudo make install;cd ..; cd ..
+
+cd cathook
+git fetch >update.log
+if ! git pull origin $(git rev-parse --abbrev-ref HEAD) >>update.log; then
+    $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
+    exit
+fi
+if ! git submodule update --remote --recursive >>update.log; then
+    $DIALOG --title "Error" --backtitle "Updating"  --msgbox "An error occured while updating cathook, check update.log for details. It might have been caused by changes in local files - in that case try resetting local repo." 8 78
+    exit
+fi
 cd build; cmake ..; make; cd ..; cd ..
+
 
 cp -a -u ./cathook/tools/. ./; rm ./README; rm ./updater
 

--- a/tools/updater.sh
+++ b/tools/updater.sh
@@ -51,5 +51,3 @@ cd build; cmake ..; make; cd ..; cd ..
 
 
 cp -a -u ./cathook/tools/. ./; rm ./README; rm ./updater
-exit
-#Important! Otherwise you will run into weird bash issues after copying files

--- a/tools/updater.sh
+++ b/tools/updater.sh
@@ -50,4 +50,4 @@ fi
 cd build; cmake ..; make; cd ..; cd ..
 
 
-cp -a -u ./cathook/tools/. ./; rm ./README; rm ./updater
+cp -a -u ./cathook/tools/. ./; rm ./README; rm ./updater.sh


### PR DESCRIPTION
The goal of this pull-request is to make updating cathook in the future as easy as possible. This pull-request is backwards compatible with previous versions of cathook (as in: It won't break them), but a reinstall(using the install script) is required in order to enable the new update script.
![grafik](https://user-images.githubusercontent.com/38938720/40300248-0356b7fa-5ce9-11e8-9919-9923c1ea2c38.png)
^ This is what the cathook folder will look like after the install. Scripts located in this folder can be updated and added by using the `tools` folder located in nullworks/cathook.

**Update Script**
The `update` script first downloads the latest version of the `updater.sh` script using wget. This ensures that the user will always have the up to date update script in case cathook's building steps have changed. Next, "updater.sh" will update all github repos and compile and install them using `make`.(Cathooks own repo will not be `make install`'d) Last, `updater.sh` will update all scripts like `attach`.

**Attach script**
Run `attach` in cathook dir

**Conclusion**
This PR allows users to always run the latest cathook version easily and allows maintainers to supply users with useful scripts.