### PR TITLE
deleted heal arrows from menu

### DIFF
--- a/src/visual/menu/ncc/Menu.cpp
+++ b/src/visual/menu/ncc/Menu.cpp
@@ -746,13 +746,6 @@ static const std::string list_tf2 = R"(
 				"autotaunt"
 				"autotaunt_chance"
 				]
-				"HealArrow" [
-					"HealArrow Menu"
-					"healarrow"
-					"healarrow_timeout"
-					"healarrow_charge"
-					"healarrow_callout"
-				]
 	]
 	"Debug" [
 		"Debug Menu"


### PR DESCRIPTION
this was recently removed from the features list so its best to remove it from the menu too