### PR TITLE
Display friend glow over health glow and add option to disable auto-rage and antiaim check

### DIFF
--- a/include/hacks/AntiCheat.hpp
+++ b/include/hacks/AntiCheat.hpp
@@ -17,7 +17,7 @@ namespace hacks::shared::anticheat
 {
 
 void Accuse(int eid, const std::string &hack, const std::string &details);
-static CatVar setrage(CV_SWITCH, "ac_setrage", "0", "Auto Rage");
+static CatVar autorage(CV_SWITCH, "ac_autorage", "0", "Auto Rage");
 void Init();
 void CreateMove();
 

--- a/include/hacks/AntiCheat.hpp
+++ b/include/hacks/AntiCheat.hpp
@@ -17,7 +17,7 @@ namespace hacks::shared::anticheat
 {
 
 void Accuse(int eid, const std::string &hack, const std::string &details);
-
+static CatVar setrage(CV_SWITCH, "ac_setrage", "0", "Auto Rage");
 void Init();
 void CreateMove();
 

--- a/src/hacks/AntiCheat.cpp
+++ b/src/hacks/AntiCheat.cpp
@@ -20,6 +20,7 @@ namespace anticheat
 
 static CatVar enabled(CV_SWITCH, "ac_enabled", "0", "Enable AC");
 static CatVar accuse_chat(CV_SWITCH, "ac_chat", "0", "Accuse in chat");
+static CatVar setrage(CV_SWITCH, "ac_setrage", "0", "Auto Rage");
 
 void Accuse(int eid, const std::string &hack, const std::string &details)
 {

--- a/src/hacks/AntiCheat.cpp
+++ b/src/hacks/AntiCheat.cpp
@@ -20,7 +20,7 @@ namespace anticheat
 
 static CatVar enabled(CV_SWITCH, "ac_enabled", "0", "Enable AC");
 static CatVar accuse_chat(CV_SWITCH, "ac_chat", "0", "Accuse in chat");
-static CatVar setrage(CV_SWITCH, "ac_setrage", "0", "Auto Rage");
+static CatVar autorage(CV_SWITCH, "ac_autorage", "0", "Auto Rage");
 
 void Accuse(int eid, const std::string &hack, const std::string &details)
 {

--- a/src/hacks/ac/aimbot.cpp
+++ b/src/hacks/ac/aimbot.cpp
@@ -63,7 +63,7 @@ void Update(CachedEntity *player)
                 // deviation, data.detections);
                 player_info_t info;
                 g_IEngine->GetPlayerInfo(player->m_IDX, &info);
-                if (am > 5 && hacks::shared::anticheat::setrage)
+                if (am > 5 && hacks::shared::anticheat::autorage)
                 {
                     playerlist::AccessData(info.friendsID).state =
                         playerlist::k_EState::RAGE;

--- a/src/hacks/ac/aimbot.cpp
+++ b/src/hacks/ac/aimbot.cpp
@@ -63,7 +63,7 @@ void Update(CachedEntity *player)
                 // deviation, data.detections);
                 player_info_t info;
                 g_IEngine->GetPlayerInfo(player->m_IDX, &info);
-                if (am > 5)
+                if (am > 5 && hacks::shared::anticheat::setrage)
                 {
                     playerlist::AccessData(info.friendsID).state =
                         playerlist::k_EState::RAGE;

--- a/src/hacks/ac/antiaim.cpp
+++ b/src/hacks/ac/antiaim.cpp
@@ -50,7 +50,7 @@ void Update(CachedEntity *player)
             am++;
             player_info_t info;
             g_IEngine->GetPlayerInfo(player->m_IDX, &info);
-            if (am > 5 && hacks::shared::anticheat::setrage)
+            if (am > 5 && hacks::shared::anticheat::autorage)
             {
                 playerlist::AccessData(info.friendsID).state =
                     playerlist::k_EState::RAGE;

--- a/src/hacks/ac/antiaim.cpp
+++ b/src/hacks/ac/antiaim.cpp
@@ -12,7 +12,7 @@ namespace ac
 {
 namespace antiaim
 {
-
+static CatVar enabled(CV_SWITCH, "ac_antiaim", "1", "Detect Antiaim");
 unsigned long last_accusation[32]{ 0 };
 
 void ResetEverything()
@@ -32,6 +32,8 @@ void Init()
 
 void Update(CachedEntity *player)
 {
+    if (!enabled)
+        return;
     int amount[32];
     auto &am = amount[player->m_IDX - 1];
     if (tickcount - last_accusation[player->m_IDX - 1] < 60 * 60)
@@ -48,7 +50,7 @@ void Update(CachedEntity *player)
             am++;
             player_info_t info;
             g_IEngine->GetPlayerInfo(player->m_IDX, &info);
-            if (am > 5)
+            if (am > 5 && hacks::shared::anticheat::setrage)
             {
                 playerlist::AccessData(info.friendsID).state =
                     playerlist::k_EState::RAGE;

--- a/src/visual/EffectGlow.cpp
+++ b/src/visual/EffectGlow.cpp
@@ -260,7 +260,7 @@ rgba_t EffectGlow::GlowColor(IClientEntity *entity)
                 return colors::red;
         if (ent->m_IDX == LOCAL_E->m_IDX && glowself && !rainbow)
             return colors::FromRGBA8(glowR, glowG, glowB, 255);
-        if (health)
+        if (health && playerlist::IsDefault(ent))
         {
             return colors::Health(ent->m_iHealth(), ent->m_iMaxHealth());
         }

--- a/src/visual/menu/ncc/Menu.cpp
+++ b/src/visual/menu/ncc/Menu.cpp
@@ -734,7 +734,7 @@ static const std::string list_tf2 = R"(
 				"ac_aimbot_detections"
 				"ac_aimbot_angle"
 				"ac_antiaim"
-				"ac_setrage"
+				"ac_autorage"
 				"ac_bhop_count"
 				"ac_ignore_local"
 				"ac_chat"

--- a/src/visual/menu/ncc/Menu.cpp
+++ b/src/visual/menu/ncc/Menu.cpp
@@ -733,6 +733,8 @@ static const std::string list_tf2 = R"(
 				"ac_aimbot"
 				"ac_aimbot_detections"
 				"ac_aimbot_angle"
+				"ac_antiaim"
+				"ac_setrage"
 				"ac_bhop_count"
 				"ac_ignore_local"
 				"ac_chat"


### PR DESCRIPTION
Correctly show friend glow first if health glow is enabled.
AC:
Add option to disable auto-rage (automatically set a target to rage if > x detections)
Add option to disable anti-aim check