### PR TITLE
Updated flags on pacman to sync package databases before installing deps

### DIFF
--- a/install-all
+++ b/install-all
@@ -11,7 +11,7 @@ rm ../install-all # remove install file
 # Install base Dependencies
 #
 if [ -f "/etc/arch-release" ]; then
-    sudo pacman -S --needed --noconfirm boost cmake make lib32-libpng gcc gdb lib32-sdl2 lib32-glew freetype2 rsync lib32-openssl
+    sudo pacman -Syy --needed --noconfirm boost cmake make lib32-libpng gcc gdb lib32-sdl2 lib32-glew freetype2 rsync lib32-openssl
 else
     sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
     sudo apt update


### PR DESCRIPTION
Some users, including myself, received 404 errors when running the install-all script on Arch. The problem for me was that I needed to sync the package databases before attempting to install lib32-glew.

This change won't affect anyone who installs with no issues already but will allow anyone with the problem to install properly without any manual intervention.