### PR TITLE
Improve Name stealer

### DIFF
--- a/src/hooks/GetFriendPersonaName.cpp
+++ b/src/hooks/GetFriendPersonaName.cpp
@@ -128,7 +128,7 @@ const char *GetNamestealName(CSteamID steam_id)
             {
 
                 // Return the name that has changed from the func above
-                return format(stolen_name, "\015").c_str();
+                return format(stolen_name, "\e").c_str();
             }
         }
     }


### PR DESCRIPTION
\r character creates long space that is detectable. \e on the other hand is fully invisible