### PR TITLE
Merge l0fg with master

### DIFF
--- a/include/PlayerTools.hpp
+++ b/include/PlayerTools.hpp
@@ -27,8 +27,8 @@ enum class IgnoreReason
     OTHER
 };
 
-IgnoreReason shouldTargetSteamId(unsigned id);
-IgnoreReason shouldTarget(CachedEntity *player);
+bool shouldTargetSteamId(unsigned id);
+bool shouldTarget(CachedEntity *player);
 
 bool shouldAlwaysRenderEspSteamId(unsigned id);
 bool shouldAlwaysRenderEsp(CachedEntity *entity);

--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -164,6 +164,7 @@ bool IsEntityVisiblePenetration(CachedEntity *entity, int hb);
 // void EndPrediction();
 
 float RandFloatRange(float min, float max);
+int UniformRandomInt(int min, int max);
 
 bool Developer(CachedEntity *ent);
 

--- a/include/reclasses/CTFPartyClient.hpp
+++ b/include/reclasses/CTFPartyClient.hpp
@@ -15,7 +15,7 @@ class CTFPartyClient
 public:
     static CTFPartyClient *GTFPartyClient();
 
-    static int SendPartyChat(CTFPartyClient *client, const char *message);
+    void SendPartyChat(const char *message);
     int LoadSavedCasualCriteria();
     static ITFGroupMatchCriteria *MutLocalGroupCriteria(CTFPartyClient *client);
     static bool BCanQueueForStandby(CTFPartyClient *this_);
@@ -29,6 +29,9 @@ public:
     static bool BInQueue(CTFPartyClient *this_);
     int GetNumOnlineMembers();
     int GetNumMembers();
+    int PromotePlayerToLeader(CSteamID steamid);
+    int KickPlayer(CSteamID steamid);
+    bool GetCurrentPartyLeader(CSteamID &id);
 };
 class ITFMatchGroupDescription
 {

--- a/src/PlayerTools.cpp
+++ b/src/PlayerTools.cpp
@@ -29,20 +29,20 @@ static CatCommand forgive_all("pt_forgive_all", "Clear betrayal list", []() { be
 namespace player_tools
 {
 
-IgnoreReason shouldTargetSteamId(unsigned id)
+bool shouldTargetSteamId(unsigned id)
 {
     if (id == 0)
-        return IgnoreReason::DO_NOT_IGNORE;
+        return false;
 
     if (betrayal_limit)
     {
         if (betrayal_list[id] > int(betrayal_limit))
-            return IgnoreReason::DO_NOT_IGNORE;
+            return false;
     }
 
     auto &pl = playerlist::AccessData(id);
     if (playerlist::IsFriendly(pl.state) || (pl.state == playerlist::k_EState::CAT && *ignoreCathook))
-        return IgnoreReason::LOCAL_PLAYER_LIST;
+        return false;
 #if ENABLE_ONLINE
     auto *co = online::getUserData(id);
     if (co)
@@ -53,31 +53,31 @@ IgnoreReason shouldTargetSteamId(unsigned id)
         if (check_verified && check_anonymous)
         {
             if (online_notarget && co->no_target)
-                return IgnoreReason::ONLINE_NO_TARGET;
+                return false;
             if (online_friendly_software && co->is_using_friendly_software)
-                return IgnoreReason::ONLINE_FRIENDLY_SOFTWARE;
+                return false;
         }
         // Always check developer status, no exceptions
         if (co->is_developer)
-            return IgnoreReason::DEVELOPER;
+            return false;
     }
 #endif
-    return IgnoreReason::DO_NOT_IGNORE;
+    return true;
 }
-IgnoreReason shouldTarget(CachedEntity *entity)
+bool shouldTarget(CachedEntity *entity)
 {
     if (entity->m_Type() == ENTITY_PLAYER)
     {
         if (hoovy && IsHoovy(entity))
-            return IgnoreReason::IS_HOOVY;
+            return false;
         if (taunting && HasCondition<TFCond_Taunting>(entity))
-            return IgnoreReason::IS_TAUNTING;
+            return false;
         if (HasCondition<TFCond_HalloweenGhostMode>(entity))
-            return IgnoreReason::OTHER;
+            return false;
         return shouldTargetSteamId(entity->player_info.friendsID);
     }
 
-    return IgnoreReason::DO_NOT_IGNORE;
+    return true;
 }
 
 bool shouldAlwaysRenderEspSteamId(unsigned id)
@@ -141,8 +141,7 @@ std::optional<colors::rgba_t> forceEspColor(CachedEntity *entity)
 
 void onKilledBy(unsigned id)
 {
-    auto reason = shouldTargetSteamId(id);
-    if (reason != IgnoreReason::DO_NOT_IGNORE)
+    if (shouldTargetSteamId(id))
     {
         // We ignored the gamer, but they still shot us
         if (betrayal_list.find(id) == betrayal_list.end())

--- a/src/PlayerTools.cpp
+++ b/src/PlayerTools.cpp
@@ -141,7 +141,7 @@ std::optional<colors::rgba_t> forceEspColor(CachedEntity *entity)
 
 void onKilledBy(unsigned id)
 {
-    if (shouldTargetSteamId(id))
+    if (!shouldTargetSteamId(id))
     {
         // We ignored the gamer, but they still shot us
         if (betrayal_list.find(id) == betrayal_list.end())

--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -540,7 +540,7 @@ bool IsTargetStateGood(CachedEntity *entity)
             }
 
             // Some global checks
-            if (player_tools::shouldTarget(entity) != player_tools::IgnoreReason::DO_NOT_IGNORE)
+            if (!player_tools::shouldTarget(entity))
                 return false;
             if (hacks::shared::catbot::should_ignore_player(entity))
                 return false;

--- a/src/hacks/AntiCheat.cpp
+++ b/src/hacks/AntiCheat.cpp
@@ -61,7 +61,7 @@ void CreateMove()
         {
             if (ent->m_bAlivePlayer())
             {
-                if (player_tools::shouldTarget(ent) == player_tools::IgnoreReason::DO_NOT_IGNORE || ent == LOCAL_E)
+                if (player_tools::shouldTarget(ent) || ent == LOCAL_E)
                 {
                     ac::aimbot::Update(ent);
                     ac::antiaim::Update(ent);

--- a/src/hacks/AutoBackstab.cpp
+++ b/src/hacks/AutoBackstab.cpp
@@ -55,7 +55,7 @@ static void doLegitBackstab()
         return;
     int index = reinterpret_cast<IClientEntity *>(trace.m_pEnt)->entindex();
     auto ent  = ENTITY(index);
-    if (index == 0 || index > g_IEngine->GetMaxClients() || !ent->m_bEnemy() || player_tools::shouldTarget(ent) != player_tools::IgnoreReason::DO_NOT_IGNORE)
+    if (index == 0 || index > g_IEngine->GetMaxClients() || !ent->m_bEnemy() || !player_tools::shouldTarget(ent))
         return;
     if (angleCheck(ENTITY(index), std::nullopt, g_pLocalPlayer->v_OrigViewangles))
     {
@@ -79,7 +79,7 @@ static void doRageBackstab()
         {
             int index = reinterpret_cast<IClientEntity *>(trace.m_pEnt)->entindex();
             auto ent  = ENTITY(index);
-            if (index == 0 || index > g_IEngine->GetMaxClients() || !ent->m_bEnemy() || player_tools::shouldTarget(ent) != player_tools::IgnoreReason::DO_NOT_IGNORE)
+            if (index == 0 || index > g_IEngine->GetMaxClients() || !ent->m_bEnemy() || !player_tools::shouldTarget(ent))
                 continue;
             if (angleCheck(ent, std::nullopt, newangle))
             {
@@ -104,7 +104,7 @@ static void doBacktrackStab()
     {
         return;
     }
-    if (!ent->m_bEnemy() || player_tools::shouldTarget(ent) != player_tools::IgnoreReason::DO_NOT_IGNORE)
+    if (!ent->m_bEnemy() || !player_tools::shouldTarget(ent))
         return;
 
     auto &btd = hacks::shared::backtrack::headPositions[ent->m_IDX];

--- a/src/hacks/AutoDetonator.cpp
+++ b/src/hacks/AutoDetonator.cpp
@@ -53,7 +53,7 @@ bool IsTarget(CachedEntity *ent)
             return false;
 
         // Global checks
-        if (player_tools::shouldTarget(ent) != player_tools::IgnoreReason::DO_NOT_IGNORE)
+        if (!player_tools::shouldTarget(ent))
             return false;
         IF_GAME(IsTF())
         {

--- a/src/hacks/AutoJoin.cpp
+++ b/src/hacks/AutoJoin.cpp
@@ -136,6 +136,7 @@ static CatCommand get_steamid("print_steamid", "Prints your SteamID", []() { g_I
 
 static InitRoutine init([]() {
     EC::Register(EC::CreateMove, update, "cm_autojoin", EC::average);
+    EC::Register(EC::Paint, updateSearch, "paint_autojoin", EC::average);
     static BytePatch p = { gSignatures.GetClientSignature, "55 89 E5 53 83 EC 14 8B 45 08 8B 40 30", 0x00, { 0x31, 0xC0, 0x40, 0xC3 } };
     if (*partybypass)
         p.Patch();

--- a/src/hacks/AutoSticky.cpp
+++ b/src/hacks/AutoSticky.cpp
@@ -56,7 +56,7 @@ bool IsTarget(CachedEntity *ent)
             return false;
 
         // Global checks
-        if (player_tools::shouldTarget(ent) != player_tools::IgnoreReason::DO_NOT_IGNORE)
+        if (!player_tools::shouldTarget(ent))
             return false;
 
         IF_GAME(IsTF())

--- a/src/hacks/CatBot.cpp
+++ b/src/hacks/CatBot.cpp
@@ -203,7 +203,7 @@ void reportall()
         if (ent == LOCAL_E)
             continue;
         player_info_s info;
-        if (g_IEngine->GetPlayerInfo(i, &info))
+        if (g_IEngine->GetPlayerInfo(i, &info) && info.friendsID)
         {
             if (!player_tools::shouldTargetSteamId(info.friendsID))
                 continue;

--- a/src/hacks/CatBot.cpp
+++ b/src/hacks/CatBot.cpp
@@ -205,7 +205,7 @@ void reportall()
         player_info_s info;
         if (g_IEngine->GetPlayerInfo(i, &info))
         {
-            if (player_tools::shouldTargetSteamId(info.friendsID) != player_tools::IgnoreReason::DO_NOT_IGNORE)
+            if (!player_tools::shouldTargetSteamId(info.friendsID))
                 continue;
             CSteamID id(info.friendsID, EUniverse::k_EUniversePublic, EAccountType::k_EAccountTypeIndividual);
             ReportPlayer_fn(id.ConvertToUint64(), 1);
@@ -234,7 +234,7 @@ void smart_crouch()
         for (int i = 0; i < g_IEngine->GetMaxClients(); i++)
         {
             auto ent = ENTITY(i);
-            if (CE_BAD(ent) || ent->m_Type() != ENTITY_PLAYER || ent->m_iTeam() == LOCAL_E->m_iTeam() || !(ent->hitboxes.GetHitbox(0)) || !(ent->m_bAlivePlayer()) || player_tools::shouldTarget(ent) != player_tools::IgnoreReason::DO_NOT_IGNORE || should_ignore_player(ent))
+            if (CE_BAD(ent) || ent->m_Type() != ENTITY_PLAYER || ent->m_iTeam() == LOCAL_E->m_iTeam() || !(ent->hitboxes.GetHitbox(0)) || !(ent->m_bAlivePlayer()) || !player_tools::shouldTarget(ent) || should_ignore_player(ent))
                 continue;
             bool failedvis = false;
             for (int j = 0; j < 18; j++)

--- a/src/hacks/CatBot.cpp
+++ b/src/hacks/CatBot.cpp
@@ -92,7 +92,8 @@ void do_random_votekick()
             continue;
         if (info.friendsID == local_info.friendsID)
             continue;
-        if (playerlist::AccessData(info.friendsID).state != playerlist::k_EState::RAGE && playerlist::AccessData(info.friendsID).state != playerlist::k_EState::DEFAULT)
+        auto &pl = playerlist::AccessData(info.friendsID);
+        if (pl.state != playerlist::k_EState::RAGE && pl.state != playerlist::k_EState::DEFAULT)
             continue;
 
         targets.push_back(info.userID);

--- a/src/hacks/CatBot.cpp
+++ b/src/hacks/CatBot.cpp
@@ -106,7 +106,7 @@ void do_random_votekick()
     player_info_s info;
     if (!g_IEngine->GetPlayerInfo(g_IEngine->GetPlayerForUserID(target), &info))
         return;
-    hack::ExecuteCommand("callvote kick " + std::to_string(target) + " cheating");
+    hack::ExecuteCommand("callvote kick \"" + std::to_string(target) + " cheating\"");
 }
 
 void update_catbot_list()

--- a/src/hacks/ESP.cpp
+++ b/src/hacks/ESP.cpp
@@ -161,7 +161,8 @@ struct bonelist_s
         Vector current_screen;
         for (int i = 0; i < size; i++)
         {
-            Vector position(bones[in[i]][0][3], bones[in[i]][1][3], bones[in[i]][2][3]);
+            const auto &bone = bones[in[i]];
+            Vector position(bone[0][3], bone[1][3], bone[2][3]);
             position += displacement;
             if (!draw::WorldToScreen(position, current_screen))
             {

--- a/src/hacks/MiscAimbot.cpp
+++ b/src/hacks/MiscAimbot.cpp
@@ -34,7 +34,7 @@ std::pair<CachedEntity *, Vector> FindBestEnt(bool teammate, bool Predict, bool 
                 continue;
             if (!ent->hitboxes.GetHitbox(1))
                 continue;
-            if (!teammate && player_tools::shouldTarget(ent) != player_tools::IgnoreReason::DO_NOT_IGNORE)
+            if (!teammate && !player_tools::shouldTarget(ent))
                 continue;
             Vector target{};
             if (Predict)

--- a/src/hacks/NavBot.cpp
+++ b/src/hacks/NavBot.cpp
@@ -123,7 +123,7 @@ static std::pair<CachedEntity *, float> getNearestPlayerDistance()
     for (int i = 1; i < g_IEngine->GetMaxClients(); i++)
     {
         CachedEntity *ent = ENTITY(i);
-        if (CE_GOOD(ent) && ent->m_bAlivePlayer() && ent->m_bEnemy() && g_pLocalPlayer->v_Origin.DistTo(ent->m_vecOrigin()) < distance && player_tools::shouldTarget(ent) == player_tools::IgnoreReason::DO_NOT_IGNORE && (!hacks::shared::aimbot::ignore_cloak || !IsPlayerInvisible(ent)) && VisCheckEntFromEnt(LOCAL_E, ent))
+        if (CE_GOOD(ent) && ent->m_bAlivePlayer() && ent->m_bEnemy() && g_pLocalPlayer->v_Origin.DistTo(ent->m_vecOrigin()) < distance && player_tools::shouldTarget(ent) && (!hacks::shared::aimbot::ignore_cloak || !IsPlayerInvisible(ent)) && VisCheckEntFromEnt(LOCAL_E, ent))
         {
             distance = g_pLocalPlayer->v_Origin.DistTo(ent->m_vecOrigin());
             best_ent = ent;
@@ -209,7 +209,7 @@ static bool stayNearPlayers(const bot_class_config &config, CachedEntity *&resul
     for (int i = 1; i < g_IEngine->GetMaxClients(); i++)
     {
         CachedEntity *ent = ENTITY(i);
-        if (CE_BAD(ent) || !ent->m_bAlivePlayer() || !ent->m_bEnemy() || player_tools::shouldTarget(ent) != player_tools::IgnoreReason::DO_NOT_IGNORE || (hacks::shared::aimbot::ignore_cloak && IsPlayerInvisible(ent)))
+        if (CE_BAD(ent) || !ent->m_bAlivePlayer() || !ent->m_bEnemy() || !player_tools::shouldTarget(ent) || (hacks::shared::aimbot::ignore_cloak && IsPlayerInvisible(ent)))
             continue;
         players.push_back(ent);
     }
@@ -267,7 +267,7 @@ static bool stayNear()
         if (CE_GOOD(last_target) && stayNearHelpers::isValidNearPosition(last_area->m_center, last_target->m_vecOrigin(), *config))
             invalid_area_time.update();
 
-        if (CE_GOOD(last_target) && (!last_target->m_bAlivePlayer() || !last_target->m_bEnemy() || player_tools::shouldTarget(last_target) != player_tools::IgnoreReason::DO_NOT_IGNORE || (hacks::shared::aimbot::ignore_cloak && IsPlayerInvisible(last_target))))
+        if (CE_GOOD(last_target) && (!last_target->m_bAlivePlayer() || !last_target->m_bEnemy() || !player_tools::shouldTarget(last_target) || (hacks::shared::aimbot::ignore_cloak && IsPlayerInvisible(last_target))))
         {
             nav::clearInstructions();
             current_task = task::none;

--- a/src/hacks/Trigger.cpp
+++ b/src/hacks/Trigger.cpp
@@ -242,7 +242,7 @@ bool IsTargetStateGood(CachedEntity *entity, bool backtrack)
             return false;
 
         // Global checks
-        if (player_tools::shouldTarget(entity) != player_tools::IgnoreReason::DO_NOT_IGNORE)
+        if (!player_tools::shouldTarget(entity))
             return false;
 
         IF_GAME(IsTF())

--- a/src/hacks/ac/aimbot.cpp
+++ b/src/hacks/ac/aimbot.cpp
@@ -111,8 +111,10 @@ void Event(KeyValues *event)
         {
             CachedEntity *victim   = ENTITY(vid);
             CachedEntity *attacker = ENTITY(eid);
-            if (Player_origs[vid].z != 0 && Player_origs[eid].z != 0)
-                if (Player_origs[vid].DistTo(Player_origs[eid]) > 250)
+            auto &Po_v = Player_origs[vid];
+            auto &Po_e = Player_origs[eid];
+            if (Po_v.z != 0 && Po_e.z != 0)
+                if (Po_v.DistTo(Po_e) > 250)
                 {
                     data_table[eid - 1].check_timer = 1;
                     data_table[eid - 1].last_weapon = event->GetInt("weaponid");

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -608,13 +608,11 @@ powerup_type GetPowerupOnPlayer(CachedEntity *player)
 // A function to tell if a player is using a specific weapon
 bool HasWeapon(CachedEntity *ent, int wantedId)
 {
-    if (CE_BAD(ent))
+    if (CE_BAD(ent) || ent->m_Type() != ENTITY_PLAYER)
         return false;
-    // Create a var to store the handle
-    int *hWeapons;
     // Grab the handle and store it into the var
-    hWeapons = (int *) ((unsigned) (RAW_ENT(ent) + netvar.hMyWeapons));
-    if (!hWeapons || !RAW_ENT(ent) || ent->m_Type() != ENTITY_PLAYER)
+    int *hWeapons = (int *) ((unsigned) (RAW_ENT(ent) + netvar.hMyWeapons));
+    if (!hWeapons)
         return false;
     // Go through the handle array and search for the item
     for (int i = 0; hWeapons[i]; i++)

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -801,6 +801,30 @@ float RandFloatRange(float min, float max)
     return (min + 1) + (((float) rand()) / (float) RAND_MAX) * (max - (min + 1));
 }
 
+int UniformRandomInt(int min, int max)
+{
+    uint32_t bound, len, r, result = 0;
+    /* Protect from random stupidity */
+    if (min > max)
+        std::swap(min, max);
+
+    len = max - min + 1;
+    /* RAND_MAX is implementation dependent.
+     * It's guaranteed that this value is at least 32767.
+     * glibc's RAND_MAX is 2^31 - 1 exactly. Since source games hard
+     * depend on glibc, we will do so as well
+     */
+    while (len)
+    {
+        bound = (1U + RAND_MAX) % len;
+        while ((r = rand()) < bound);
+        result *= 1U + RAND_MAX;
+        result += r % len;
+        len -= len > RAND_MAX ? RAND_MAX : len;
+    }
+    return int(result) + min;
+}
+
 bool IsEntityVisible(CachedEntity *entity, int hb)
 {
     if (g_Settings.bInvalid)

--- a/src/hooks/GetFriendPersonaName.cpp
+++ b/src/hooks/GetFriendPersonaName.cpp
@@ -56,7 +56,7 @@ bool StolenName()
             if (std::strlen(info.name) >= 31)
                 continue;
             // Ignore Friendly
-            if (player_tools::shouldTargetSteamId(info.friendsID) != player_tools::IgnoreReason::DO_NOT_IGNORE)
+            if (!player_tools::shouldTargetSteamId(info.friendsID))
                 continue;
             // If our name is the same as current, then change it
             if (stolen_name == info.name && *namesteal == 1)

--- a/src/hooks/Paint.cpp
+++ b/src/hooks/Paint.cpp
@@ -54,7 +54,6 @@ DEFINE_HOOKED_METHOD(Paint, void, IEngineVGui *this_, PaintMode_t mode)
             }
         }
 #endif
-        hacks::shared::autojoin::updateSearch();
         if (!hack::command_stack().empty())
         {
             PROF_SECTION(PT_command_stack);

--- a/src/playerlist.cpp
+++ b/src/playerlist.cpp
@@ -167,6 +167,27 @@ bool IsDefault(CachedEntity *entity)
 CatCommand pl_save("pl_save", "Save playerlist", Save);
 CatCommand pl_load("pl_load", "Load playerlist", Load);
 
+CatCommand pl_add_id("pl_add_id", "Sets state for steamid", [](const CCommand &args) {
+    if (args.ArgC() <= 2)
+        return;
+
+    uint32_t id = std::strtoul(args.Arg(1), nullptr, 10);
+    auto &pl = AccessData(id);
+    const char *state = args.Arg(2);
+    if (k_Names[0] == state)
+        pl.state = k_EState::DEFAULT;
+    else if (k_Names[1] == state)
+        pl.state = k_EState::FRIEND;
+    else if (k_Names[2] == state)
+        pl.state = k_EState::RAGE;
+    else if (k_Names[3] == state)
+        pl.state = k_EState::IPC;
+    else if (k_Names[4] == state)
+        pl.state = k_EState::DEVELOPER;
+    else
+        logging::Info("Unknown State");
+});
+
 CatCommand pl_set_state("pl_set_state", "cat_pl_set_state [playername] [state] (Tab to autocomplete)", [](const CCommand &args) {
     if (args.ArgC() != 3)
     {
@@ -198,16 +219,17 @@ CatCommand pl_set_state("pl_set_state", "cat_pl_set_state [playername] [state] (
     player_info_s info;
     g_IEngine->GetPlayerInfo(id, &info);
 
+    auto &pl = AccessData(info.friendsID);
     if (k_Names[0] == state)
-        AccessData(info.friendsID).state = k_EState::DEFAULT;
+        pl.state = k_EState::DEFAULT;
     else if (k_Names[1] == state)
-        AccessData(info.friendsID).state = k_EState::FRIEND;
+        pl.state = k_EState::FRIEND;
     else if (k_Names[2] == state)
-        AccessData(info.friendsID).state = k_EState::RAGE;
+        pl.state = k_EState::RAGE;
     else if (k_Names[3] == state)
-        AccessData(info.friendsID).state = k_EState::IPC;
+        pl.state = k_EState::IPC;
     else if (k_Names[4] == state)
-        AccessData(info.friendsID).state = k_EState::DEVELOPER;
+        pl.state = k_EState::DEVELOPER;
     else
         logging::Info("Unknown State. (Use tab for autocomplete)");
 });

--- a/src/reclasses/CTFGCClientSystem.cpp
+++ b/src/reclasses/CTFGCClientSystem.cpp
@@ -13,7 +13,7 @@ using namespace re;
 CTFGCClientSystem *CTFGCClientSystem::GTFGCClientSystem()
 {
     typedef CTFGCClientSystem *(*GTFGCClientSystem_t)();
-    static uintptr_t addr1                          = gSignatures.GetClientSignature("55 B8 ? ? ? ? 89 E5 5D C3 8D B6 00 00 00 00 55 A1 ? ? ? ? 89 E5 5D C3 "
+    static uintptr_t addr1 = gSignatures.GetClientSignature("55 B8 ? ? ? ? 89 E5 5D C3 8D B6 00 00 00 00 55 A1 ? ? ? ? 89 E5 5D C3 "
                                                             "8D B6 00 00 00 00 A1");
     static GTFGCClientSystem_t GTFGCClientSystem_fn = GTFGCClientSystem_t(addr1);
 
@@ -27,7 +27,7 @@ void CTFGCClientSystem::AbandonCurrentMatch()
     static AbandonCurrentMatch_t AbandonCurrentMatch_fn = AbandonCurrentMatch_t(addr1);
     if (AbandonCurrentMatch_fn == nullptr)
     {
-        logging::Info("calling NULL!");
+        logging::Info("CTFGCClientSystem::AbandonCurrentMatch() calling NULL!");
     }
     AbandonCurrentMatch_fn(this);
 }
@@ -47,7 +47,7 @@ bool CTFGCClientSystem::BHaveLiveMatch()
     static uintptr_t addr = gSignatures.GetClientSignature("55 31 C0 89 E5 53 8B 4D ? 0F B6 91");
     if (!addr)
     {
-        logging::Info("calling NULL!");
+        logging::Info("CTFGCClientSystem::BHaveLiveMatch() calling NULL!");
         addr = gSignatures.GetClientSignature("55 31 C0 89 E5 53 8B 4D ? 0F B6 91");
         return true;
     }
@@ -68,7 +68,7 @@ int CTFGCClientSystem::JoinMMMatch()
     static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 56 53 83 EC ? 8B 5D ? 0F B6 83 ? ? ? ? 89 C2");
     if (!addr)
     {
-        logging::Info("calling NULL!");
+        logging::Info("CTFGCClientSystem::JoinMMMatch() calling NULL!");
         addr = gSignatures.GetClientSignature("55 89 E5 56 53 83 EC ? 8B 5D ? 0F B6 83 ? ? ? ? 89 C2");
         return true;
     }

--- a/src/reclasses/CTFPartyClient.cpp
+++ b/src/reclasses/CTFPartyClient.cpp
@@ -11,7 +11,7 @@
 re::CTFPartyClient *re::CTFPartyClient::GTFPartyClient()
 {
     typedef re::CTFPartyClient *(*GTFPartyClient_t)(void);
-    static uintptr_t addr                     = gSignatures.GetClientSignature("55 A1 ? ? ? ? 89 E5 5D C3 8D B6 00 00 00 00 A1 ? ? ? ? 85 C0");
+    static uintptr_t addr = gSignatures.GetClientSignature("55 A1 ? ? ? ? 89 E5 5D C3 8D B6 00 00 00 00 A1 ? ? ? ? 85 C0");
     static GTFPartyClient_t GTFPartyClient_fn = GTFPartyClient_t(addr);
 
     return GTFPartyClient_fn();
@@ -24,7 +24,7 @@ bool re::CTFPartyClient::BInQueue(re::CTFPartyClient *this_)
 int re::CTFPartyClient::GetNumOnlineMembers()
 {
     typedef int (*GetNumOnlineMembers_t)(re::CTFPartyClient *);
-    static uintptr_t addr                               = gSignatures.GetClientSignature("55 89 E5 57 56 53 83 EC ? 8B 7D ? 8B 77 ? 85 F6 0F 84");
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 57 56 53 83 EC ? 8B 7D ? 8B 77 ? 85 F6 0F 84");
     static GetNumOnlineMembers_t GetNumOnlineMembers_fn = GetNumOnlineMembers_t(addr);
 
     return GetNumOnlineMembers_fn(this);
@@ -32,20 +32,24 @@ int re::CTFPartyClient::GetNumOnlineMembers()
 int re::CTFPartyClient::GetNumMembers()
 {
     typedef int (*GetNumMembers_t)(re::CTFPartyClient *);
-    static uintptr_t addr                   = gSignatures.GetClientSignature("55 89 E5 8B 45 ? 8B 50 ? C6 80") + 0x30;
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 8B 45 ? 8B 50 ? C6 80") + 0x30;
     static GetNumMembers_t GetNumMembers_fn = GetNumMembers_t(addr);
 
     return GetNumMembers_fn(this);
 }
-int re::CTFPartyClient::SendPartyChat(re::CTFPartyClient *client, const char *message)
+void re::CTFPartyClient::SendPartyChat(const char *message)
 {
-    // todo
+    typedef void (*SendPartyChat_t)(re::CTFPartyClient *, const char *);
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 57 56 53 81 EC ? ? ? ? 8B 5D 0C 89 1C 24");
+    static SendPartyChat_t SendPartyChat_fn = SendPartyChat_t(addr);
+
+    SendPartyChat_fn(this, message);
 }
 
 bool re::CTFPartyClient::BCanQueueForStandby(re::CTFPartyClient *this_)
 {
     typedef bool (*BCanQueueForStandby_t)(re::CTFPartyClient *);
-    static uintptr_t addr                               = gSignatures.GetClientSignature("55 89 E5 53 83 EC 24 8B 5D 08 80 7B 46 00 75 40 8B 4B 38 85 C9 74 39 "
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 53 83 EC 24 8B 5D 08 80 7B 46 00 75 40 8B 4B 38 85 C9 74 39 "
                                                            "E8 ? ? ? ? 89 04 24 E8 ? ? ? ? 84 C0 75 28");
     static BCanQueueForStandby_t BCanQueueForStandby_fn = BCanQueueForStandby_t(addr);
 
@@ -55,7 +59,7 @@ bool re::CTFPartyClient::BCanQueueForStandby(re::CTFPartyClient *this_)
 re::ITFGroupMatchCriteria *re::CTFPartyClient::MutLocalGroupCriteria(re::CTFPartyClient *client)
 {
     typedef re::ITFGroupMatchCriteria *(*MutLocalGroupCriteria_t)(re::CTFPartyClient *);
-    static uintptr_t addr                                   = gSignatures.GetClientSignature("55 89 E5 8B 45 ? 8B 50 ? C6 80");
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 8B 45 ? 8B 50 ? C6 80");
     static MutLocalGroupCriteria_t MutLocalGroupCriteria_fn = MutLocalGroupCriteria_t(addr);
 
     return MutLocalGroupCriteria_fn(client);
@@ -65,8 +69,7 @@ int re::CTFPartyClient::LoadSavedCasualCriteria()
 {
     typedef int (*LoadSavedCasualCriteria_t)(re::CTFPartyClient *);
     static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 8B 45 ? 5D 8B 80 ? ? ? ? C3 66 90 55 89 E5 "
-                                                           "8B 45 ? 5D 0F B6 80 ? ? ? ? C3 90 55 89 E5 56") -
-                            0x40;
+                                                           "8B 45 ? 5D 0F B6 80 ? ? ? ? C3 90 55 89 E5 56") - 0x40;
     static LoadSavedCasualCriteria_t LoadSavedCasualCriteria_fn = LoadSavedCasualCriteria_t(addr);
 
     return LoadSavedCasualCriteria_fn(this);
@@ -74,7 +77,7 @@ int re::CTFPartyClient::LoadSavedCasualCriteria()
 void re::CTFPartyClient::RequestQueueForStandby()
 {
     typedef void (*RequestStandby_t)(re::CTFPartyClient *);
-    static uintptr_t addr                     = gSignatures.GetClientSignature("55 89 E5 57 56 53 83 EC ? 8B 7D ? 8B 4F ? 85 C9 74");
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 57 56 53 83 EC ? 8B 7D ? 8B 4F ? 85 C9 74");
     static RequestStandby_t RequestStandby_fn = RequestStandby_t(addr);
     RequestStandby_fn(this);
     return;
@@ -82,7 +85,7 @@ void re::CTFPartyClient::RequestQueueForStandby()
 char re::CTFPartyClient::RequestQueueForMatch(int type)
 {
     typedef char (*RequestQueueForMatch_t)(re::CTFPartyClient *, int);
-    static uintptr_t addr                                 = gSignatures.GetClientSignature("55 89 E5 57 56 53 81 EC ? ? ? ? 8B 45 ? E8");
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 57 56 53 81 EC ? ? ? ? 8B 45 ? E8");
     static RequestQueueForMatch_t RequestQueueForMatch_fn = RequestQueueForMatch_t(addr);
 
     return RequestQueueForMatch_fn(this, type);
@@ -90,7 +93,7 @@ char re::CTFPartyClient::RequestQueueForMatch(int type)
 bool re::CTFPartyClient::BInQueueForMatchGroup(int type)
 {
     typedef bool (*BInQueueForMatchGroup_t)(re::CTFPartyClient *, int);
-    static uintptr_t addr                                   = gSignatures.GetClientSignature("55 89 E5 56 53 8B 5D ? 8B 75 ? 89 D8 E8 ? ? ? ? 84 C0 74 ? 8B 4E");
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 56 53 8B 5D ? 8B 75 ? 89 D8 E8 ? ? ? ? 84 C0 74 ? 8B 4E");
     static BInQueueForMatchGroup_t BInQueueForMatchGroup_fn = BInQueueForMatchGroup_t(addr);
 
     return BInQueueForMatchGroup_fn(this, type);
@@ -102,7 +105,7 @@ bool re::CTFPartyClient::BInQueueForStandby()
 char re::CTFPartyClient::RequestLeaveForMatch(int type)
 {
     typedef char (*RequestLeaveForMatch_t)(re::CTFPartyClient *, int);
-    static uintptr_t addr                                 = gSignatures.GetClientSignature("55 89 E5 57 56 53 83 EC ? 8B 45 ? 89 44 24 ? 8B 45 ? 89 04 24 E8 ? ? "
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 57 56 53 83 EC ? 8B 45 ? 89 44 24 ? 8B 45 ? 89 04 24 E8 ? ? "
                                                            "? ? 84 C0 89 C6 75");
     static RequestLeaveForMatch_t RequestLeaveForMatch_fn = RequestLeaveForMatch_t(addr);
 
@@ -111,23 +114,48 @@ char re::CTFPartyClient::RequestLeaveForMatch(int type)
 int re::CTFPartyClient::BInvitePlayerToParty(CSteamID steamid)
 {
     typedef int (*BInvitePlayerToParty_t)(re::CTFPartyClient *, CSteamID, bool);
-    static uintptr_t addr                                 = gSignatures.GetClientSignature("55 89 E5 57 56 53 81 EC ? ? ? ? 8B 45 ? 8B 5D ? 8B 55 ? 89 85 ? ? ? ? "
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 57 56 53 81 EC ? ? ? ? 8B 45 ? 8B 5D ? 8B 55 ? 89 85 ? ? ? ? "
                                                            "65 A1 ? ? ? ? 89 45 ? 31 C0 8B 45");
     static BInvitePlayerToParty_t BInvitePlayerToParty_fn = BInvitePlayerToParty_t(addr);
     return BInvitePlayerToParty_fn(this, steamid, false);
 }
 int re::CTFPartyClient::BRequestJoinPlayer(CSteamID steamid)
 {
+    // 55 89 E5 57 56 53 81 EC 8C 00 00 00 8B 45 14 8B 55 10 89 45 A4 8B 45 0C
     typedef int (*BRequestJoinPlayer_t)(re::CTFPartyClient *, CSteamID, bool);
-    static uintptr_t addr                             = gSignatures.GetClientSignature("55 89 E5 57 56 53 81 EC ? ? ? ? 8B 45 ? 8B 5D ? 8B 55 ? 89 85 ? ? ? ? "
-                                                           "65 A1 ? ? ? ? 89 45 ? 31 C0 8B 45");
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 57 56 53 81 EC ? ? ? ? 8B 45 14 8B 55 ? 89 45 ? 8B");
     static BRequestJoinPlayer_t BRequestJoinPlayer_fn = BRequestJoinPlayer_t(addr);
     return BRequestJoinPlayer_fn(this, steamid, false);
+}
+int re::CTFPartyClient::PromotePlayerToLeader(CSteamID steamid)
+{
+    typedef int (*PromotePlayerToLeader_t)(re::CTFPartyClient *, CSteamID);
+    static uintptr_t addr = gSignatures.GetClientSignature("8B 55 08 8B 8A A0 01 00 00 8B 92 9C 01 00 00 89 04 24 89 4C 24 08 89 54 24 04 E8") + 27;
+    static PromotePlayerToLeader_t PromotePlayerToLeader_fn = PromotePlayerToLeader_t(e8call(reinterpret_cast<void *>(addr)));
+
+    return PromotePlayerToLeader_fn(this, steamid);
+}
+int re::CTFPartyClient::KickPlayer(CSteamID steamid)
+{
+    typedef int (*KickPlayer_t)(re::CTFPartyClient *, CSteamID);
+    static uintptr_t addr = gSignatures.GetClientSignature("8B 93 9C 01 00 00 8B 8B A0 01 00 00 89 04 24 89 54 24 04 89 4C 24 08 E8") + 24;
+    static KickPlayer_t KickPlayer_fn = KickPlayer_t(e8call(reinterpret_cast<void *>(addr)));
+
+    return KickPlayer_fn(this, steamid);
+}
+bool re::CTFPartyClient::GetCurrentPartyLeader(CSteamID &id)
+{
+    uintptr_t party = *reinterpret_cast<uintptr_t *>(reinterpret_cast<uintptr_t>(this) + 0x30);
+    if (!party)
+        return false;
+
+    id = *reinterpret_cast<CSteamID *>(party + 0x1C);
+    return true;
 }
 re::ITFMatchGroupDescription *re::GetMatchGroupDescription(int &idx)
 {
     typedef re::ITFMatchGroupDescription *(*GetMatchGroupDescription_t)(int &);
-    static uintptr_t addr                                         = gSignatures.GetClientSignature("55 89 E5 8B 45 ? 8B 00 83 F8 ? 77");
+    static uintptr_t addr = gSignatures.GetClientSignature("55 89 E5 8B 45 ? 8B 00 83 F8 ? 77");
     static GetMatchGroupDescription_t GetMatchGroupDescription_fn = GetMatchGroupDescription_t(addr);
 
     return GetMatchGroupDescription_fn(idx);

--- a/src/settings/SettingsIO.cpp
+++ b/src/settings/SettingsIO.cpp
@@ -80,6 +80,7 @@ void settings::SettingsWriter::writeEscaped(std::string str)
         case '#':
         case '\n':
         case '=':
+        case '\\':
             stream << '\\';
             break;
         default:

--- a/src/votelogger.cpp
+++ b/src/votelogger.cpp
@@ -22,7 +22,7 @@ static bool was_local_player{ false };
 static void vote_rage_back()
 {
     static Timer attempt_vote_time;
-    char cmd[36];
+    char cmd[40];
     player_info_s info;
     std::vector<int> targets;
 
@@ -46,8 +46,8 @@ static void vote_rage_back()
     if (targets.empty())
         return;
 
-    std::snprintf(cmd, sizeof(cmd), "callvote kick %d cheating", targets[UniformRandomInt(0, targets.size() - 1)]);
-    g_IEngine->ExecuteClientCmd(cmd);
+    std::snprintf(cmd, sizeof(cmd), "callvote kick \"%d cheating\"", targets[UniformRandomInt(0, targets.size() - 1)]);
+    g_IEngine->ClientCmd_Unrestricted(cmd);
 }
 
 void dispatchUserMessage(bf_read &buffer, int type)


### PR DESCRIPTION
More changes than expected
Overview:
- Added rage vote kick. Set RAGE state to player who attempted to kick friendly player. Attempt to vote kick players with RAGE state (controllable with `votelogger.autovote.no.rage`). Works only when `votelogger.autovote.no` is set to `true`
- Fix kick reason being ignored in vote kick command
- Add various party related signatures
- Use SendPartyChat function instead of constructing `say_party` command (that involved hacky `;` symbol replacements) in src/votelogger.cpp
- Fix `\` symbol not saved in settings
- Fix reporting mechanism reporting players with no steamID
- Added cat_pl_add_id. Now instead of using unreliable cat_pl_save/cat_pl_load you can maintain cfg file with all cat_pl_add_id (worthwhile note: files produced with cat_pl_save when ENABLE_VISUALS != 0 aren't compatible with ENABLE_VISUALS == 0 ones, because ENABLE_VISUALS != 0 introduces color field)
- Refactoring in some places. Mostly minor, but shouldTarget{,SteamId} is worth to double checking. shouldTarget{,SteamId} return true when it should target uses (i.e. reason equals to DO_NOT_IGNORE) and false otherwise