### PR TITLE
Add legit backtrack to autobackstab

### DIFF
--- a/data/menu/nullifiedcat/trigger/autobackstab.xml
+++ b/data/menu/nullifiedcat/trigger/autobackstab.xml
@@ -7,6 +7,7 @@
                     <Option name="Legit" value="0"/>
                     <Option name="Rage" value="1"/>
                     <Option name="Backtrack" value="2"/>
+                    <Option name="Legit Backtrack" value="3"/>
                 </Select>
             </LabeledObject>
         </List>

--- a/src/hacks/AutoBackstab.cpp
+++ b/src/hacks/AutoBackstab.cpp
@@ -215,25 +215,26 @@ static void doLegitBacktrackStab() //lol
             Vector hit;
             if (hacks::shared::triggerbot::CheckLineBox(minz, maxz, g_pLocalPlayer->v_Eye, GetForwardVector(g_pLocalPlayer->v_Eye, newangle, swingrange), hit))
                 yangles_tmp.push_back(newangle.y);
-        if (!yangles_tmp.empty())
-        {
-            yangles.clear();
-            best_scr  = distcheck.DistTo(g_pLocalPlayer->v_Eye);
-            best_tick = &i;
-            yangles   = yangles_tmp;
+
+            if (!yangles_tmp.empty())
+            {
+                yangles.clear();
+                best_scr  = distcheck.DistTo(g_pLocalPlayer->v_Eye);
+                best_tick = &i;
+                yangles   = yangles_tmp;
+            }
         }
     }
-}
-if (!yangles.empty() && best_tick)
-{
-    newangle.y                   = yangles.at(std::floor((float) yangles.size() / 2));
-    current_user_cmd->tick_count = best_tick->tickcount;
-    current_user_cmd->viewangles = newangle;
-    current_user_cmd->buttons |= IN_ATTACK;
-    g_pLocalPlayer->bUseSilentAngles = true;
-}
-if (!*bSendPackets)
-    *bSendPackets = true;
+    if (!yangles.empty() && best_tick)
+    {
+        newangle.y                   = yangles.at(std::floor((float) yangles.size() / 2));
+        current_user_cmd->tick_count = best_tick->tickcount;
+        current_user_cmd->viewangles = newangle;
+        current_user_cmd->buttons |= IN_ATTACK;
+        g_pLocalPlayer->bUseSilentAngles = true;
+    }
+    if (!*bSendPackets)
+        *bSendPackets = true;
 }
 
 

--- a/src/hacks/AutoBackstab.cpp
+++ b/src/hacks/AutoBackstab.cpp
@@ -168,6 +168,75 @@ static void doBacktrackStab()
         *bSendPackets = true;
 }
 
+static void doLegitBacktrackStab() //lol
+{
+    float swingrange = re::C_TFWeaponBaseMelee::GetSwingRange(RAW_ENT(LOCAL_W));
+    CachedEntity *ent;
+    if (hacks::shared::backtrack::iBestTarget < 1)
+        return;
+    ent = ENTITY(hacks::shared::backtrack::iBestTarget);
+    if (!ent->m_bEnemy() || !player_tools::shouldTarget(ent))
+        return;
+    auto &btd       = hacks::shared::backtrack::headPositions[ent->m_IDX];
+    Vector newangle = g_pLocalPlayer->v_OrigViewangles;
+    std::vector<float> yangles;
+    float best_scr = FLT_MAX;
+    hacks::shared::backtrack::BacktrackData *best_tick;
+    for (int ii = 0; ii < 66; ii++)
+    {
+        std::vector<float> yangles_tmp;
+        auto &i = btd[ii];
+
+        Vector distcheck = i.entorigin;
+        distcheck.z      = g_pLocalPlayer->v_Eye.z;
+        if (distcheck.DistTo(g_pLocalPlayer->v_Eye) < best_scr && distcheck.DistTo(g_pLocalPlayer->v_Eye) > 20.0f)
+        {
+            if (!hacks::shared::backtrack::ValidTick(i, ent))
+                continue;
+            if (!angleCheck(ent, i.entorigin, newangle))
+                continue;
+
+            Vector &min = i.collidable.min;
+            Vector &max = i.collidable.max;
+
+            // Get the min and max for the hitbox
+            Vector minz(fminf(min.x, max.x), fminf(min.y, max.y), fminf(min.z, max.z));
+            Vector maxz(fmaxf(min.x, max.x), fmaxf(min.y, max.y), fmaxf(min.z, max.z));
+
+            // Shrink the hitbox here
+            Vector size = maxz - minz;
+            Vector smod = { size.x * 0.20f, size.y * 0.20f, 0 };
+
+            // Save the changes to the vectors
+            minz += smod;
+            maxz -= smod;
+            maxz.z += 20.0f;
+
+            Vector hit;
+            if (hacks::shared::triggerbot::CheckLineBox(minz, maxz, g_pLocalPlayer->v_Eye, GetForwardVector(g_pLocalPlayer->v_Eye, newangle, swingrange), hit))
+                yangles_tmp.push_back(newangle.y);
+        if (!yangles_tmp.empty())
+        {
+            yangles.clear();
+            best_scr  = distcheck.DistTo(g_pLocalPlayer->v_Eye);
+            best_tick = &i;
+            yangles   = yangles_tmp;
+        }
+    }
+}
+if (!yangles.empty() && best_tick)
+{
+    newangle.y                   = yangles.at(std::floor((float) yangles.size() / 2));
+    current_user_cmd->tick_count = best_tick->tickcount;
+    current_user_cmd->viewangles = newangle;
+    current_user_cmd->buttons |= IN_ATTACK;
+    g_pLocalPlayer->bUseSilentAngles = true;
+}
+if (!*bSendPackets)
+    *bSendPackets = true;
+}
+
+
 void CreateMove()
 {
     if (!enabled)
@@ -181,15 +250,21 @@ void CreateMove()
     case 0:
         doLegitBackstab();
         break;
+    case 1:
+        doRageBackstab();
+        break;
     case 2:
         if (hacks::shared::backtrack::isBacktrackEnabled)
         {
             doBacktrackStab();
             break;
         }
-    case 1:
-        doRageBackstab();
-        break;
+    case 3:
+        if (hacks::shared::backtrack::isBacktrackEnabled)
+        {
+            doLegitBacktrackStab();
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
[I wanted this to be added a long time ago](https://github.com/nullworks/cathook/issues/651#issuecomment-449452131), but it never got added

Its just the doBacktrackStab() method, but the for angle loop removed (basically triggerbot, but the code is trash). I removed it since a lot of server mods ban you for doing a quick spin and it looks suspicious.

I dont expect this to be merged, since the code is just copy pasted (and it could be made better)