### PR TITLE
WIP: New FSN/RecvTable proxy resolver

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -28,20 +28,13 @@ extern bool need_name_change;
 extern int last_cmd_number;
 
 extern time_t time_injected;
-struct brutestruct
-{
-    int brutenum[PLAYER_ARRAY_SIZE];
-    Vector last_angles[PLAYER_ARRAY_SIZE];
-    std::deque<bool> choke[PLAYER_ARRAY_SIZE];
-    float lastsimtime;
-};
+
 class GlobalSettings
 {
 public:
     void Init();
     bool bInvalid{ true };
     bool is_create_move{ false };
-    brutestruct brute;
 };
 
 bool isHackActive();

--- a/include/hacks/Aimbot.hpp
+++ b/include/hacks/Aimbot.hpp
@@ -48,7 +48,7 @@ bool ShouldAim();
 CachedEntity *RetrieveBestTarget(bool aimkey_state, bool Backtracking = false);
 bool IsTargetStateGood(CachedEntity *entity);
 void Aim(CachedEntity *entity);
-void DoAutoshoot();
+void DoAutoshoot(CachedEntity *target = nullptr);
 int BestHitbox(CachedEntity *target);
 int ClosestHitbox(CachedEntity *target);
 void DoSlowAim(Vector &inputAngle);

--- a/include/hacks/AntiAntiAim.hpp
+++ b/include/hacks/AntiAntiAim.hpp
@@ -2,17 +2,28 @@
   Created on 29.07.18.
 */
 
+#include <optional>
+#include "mathlib/vector.h"
+#include "cdll_int.h"
+
 #pragma once
-#include <core/interfaces.hpp>
-#include <core/sdk.hpp>
-#include <globals.h>
-#include <core/netvars.hpp>
-#include <settings/Bool.hpp>
-#include <localplayer.hpp>
-#include <entitycache.hpp>
+class IClientEntity;
+
+struct brutedata
+{
+    int brutenum{ 0 };
+    int hits_in_a_row{ 0 };
+    Vector original_angle;
+    Vector new_angle;
+};
 
 namespace hacks::shared::anti_anti_aim
 {
-void createMove();
-void resolveEnt(int IDX, IClientEntity *entity = nullptr);
+extern std::unordered_map<unsigned, brutedata> resolver_map;
+void increaseBruteNum(int idx);
+void frameStageNotify(ClientFrameStage_t stage);
+Vector resolveAngle(Vector angles, brutedata &brute);
+void ResetPlayer(unsigned steamid);
+void ResetPlayer(int idx);
+// void resolveEnt(int IDX, IClientEntity *entity = nullptr);
 } // namespace hacks::shared::anti_anti_aim

--- a/include/hitrate.hpp
+++ b/include/hitrate.hpp
@@ -14,5 +14,6 @@ extern int count_shots;
 extern int count_hits;
 extern int count_hits_head;
 
+void AimbotShot(int idx, bool target_body);
 void Update();
 } // namespace hitrate

--- a/include/sdk/dt_recv_redef.h
+++ b/include/sdk/dt_recv_redef.h
@@ -1,0 +1,84 @@
+#include "dt_common.h"
+#include "tier0/dbg.h"
+#include "dt_recv.h"
+
+class RecvPropRedef
+{
+    // This info comes from the receive data table.
+public:
+    RecvPropRedef();
+
+    void InitArray(int nElements, int elementStride);
+
+    int GetNumElements() const;
+    void SetNumElements(int nElements);
+
+    int GetElementStride() const;
+    void SetElementStride(int stride);
+
+    int GetFlags() const;
+
+    const char *GetName() const;
+    SendPropType GetType() const;
+
+    RecvTable *GetDataTable() const;
+    void SetDataTable(RecvTable *pTable);
+
+    RecvVarProxyFn GetProxyFn() const;
+    void SetProxyFn(RecvVarProxyFn fn);
+
+    DataTableRecvVarProxyFn GetDataTableProxyFn() const;
+    void SetDataTableProxyFn(DataTableRecvVarProxyFn fn);
+
+    int GetOffset() const;
+    void SetOffset(int o);
+
+    // Arrays only.
+    RecvProp *GetArrayProp() const;
+    void SetArrayProp(RecvProp *pProp);
+
+    // Arrays only.
+    void SetArrayLengthProxy(ArrayLengthRecvProxyFn proxy);
+    ArrayLengthRecvProxyFn GetArrayLengthProxy() const;
+
+    bool IsInsideArray() const;
+    void SetInsideArray();
+
+    // Some property types bind more data to the prop in here.
+    const void *GetExtraData() const;
+    void SetExtraData(const void *pData);
+
+    // If it's one of the numbered "000", "001", etc properties in an array, then
+    // these can be used to get its array property name for debugging.
+    const char *GetParentArrayPropName();
+    void SetParentArrayPropName(const char *pArrayPropName);
+
+public:
+    const char *m_pVarName;
+    SendPropType m_RecvType;
+    int m_Flags;
+    int m_StringBufferSize;
+
+public:
+    bool m_bInsideArray; // Set to true by the engine if this property sits inside an array.
+
+    // Extra data that certain special property types bind to the property here.
+    const void *m_pExtraData;
+
+    // If this is an array (DPT_Array).
+    RecvProp *m_pArrayProp;
+    ArrayLengthRecvProxyFn m_ArrayLengthProxy;
+
+    RecvVarProxyFn m_ProxyFn;
+    DataTableRecvVarProxyFn m_DataTableProxyFn; // For RDT_DataTable.
+
+    RecvTable *m_pDataTable; // For RDT_DataTable.
+    int m_Offset;
+
+    int m_ElementStride;
+    int m_nElements;
+
+    // If it's one of the numbered "000", "001", etc properties in an array, then
+    // these can be used to get its array property name for debugging.
+    const char *m_pParentArrayPropName;
+};

--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -15,6 +15,7 @@
 #include "common.hpp"
 #include "MiscTemporary.hpp"
 #include <targethelper.hpp>
+#include "hitrate.hpp"
 
 #if ENABLE_VISUALS
 #ifndef FEATURE_EFFECTS_DISABLED
@@ -294,12 +295,12 @@ static void CreateMove()
         else if (CanShoot() && CE_INT(g_pLocalPlayer->weapon(), netvar.m_iClip1) != 0)
         {
             Aim(target_entity);
-            DoAutoshoot();
+            DoAutoshoot(target_entity);
         }
     }
     else
     {
-        DoAutoshoot();
+        DoAutoshoot(target_entity);
         Aim(target_entity);
     }
 }
@@ -829,7 +830,7 @@ void Aim(CachedEntity *entity)
 // A function to check whether player can autoshoot
 bool begancharge = false;
 int begansticky  = 0;
-void DoAutoshoot()
+void DoAutoshoot(CachedEntity *target_entity)
 {
     // Enable check
     if (!autoshoot)
@@ -919,10 +920,16 @@ void DoAutoshoot()
         attack = false;
 
     if (attack)
+    {
         // TO DO: Sending both reload and attack will activate the hitmans heatmaker ability
         // Don't activate it only on first kill (or somehow activate it before shoot)
         current_user_cmd->buttons |= IN_ATTACK | (*autoreload && CarryingHeatmaker() ? IN_RELOAD : 0);
-
+        if (target_entity)
+        {
+            auto hitbox = calculated_data_array[target_entity->m_IDX].hitbox;
+            hitrate::AimbotShot(target_entity->m_IDX, hitbox != head);
+        }
+    }
     if (LOCAL_W->m_iClassID() == CL_CLASS(CTFLaserPointer))
         current_user_cmd->buttons |= IN_ATTACK2;
     hacks::shared::antiaim::SetSafeSpace(1);

--- a/src/hacks/AntiAntiAim.cpp
+++ b/src/hacks/AntiAntiAim.cpp
@@ -2,28 +2,137 @@
  * Created on 29.07.18.
  */
 
-#include <common.hpp>
-#include <hacks/AntiAntiAim.hpp>
+#include "common.hpp"
+#include "hacks/AntiAntiAim.hpp"
+#include "sdk/dt_recv_redef.h"
+#include "sdk.hpp"
 
 namespace hacks::shared::anti_anti_aim
 {
 static settings::Boolean enable{ "anti-anti-aim.enable", "false" };
+static settings::Boolean debug{ "anti-anti-aim.debug.force-rotate", "false" };
 
-void createMove()
+std::unordered_map<unsigned, brutedata> resolver_map;
+
+void frameStageNotify(ClientFrameStage_t stage)
 {
-    if (!enable)
+    if (!enable || !g_IEngine->IsInGame())
         return;
-    if (CE_BAD(LOCAL_E))
-        return;
-
-    IClientEntity *entity{ nullptr };
-    for (int i = 0; i <= g_IEngine->GetMaxClients(); i++)
+    if (stage == FRAME_NET_UPDATE_POSTDATAUPDATE_START)
     {
-        resolveEnt(i, entity);
+        for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+        {
+            auto player = ENTITY(i);
+            if (CE_BAD(player) || !player->m_bAlivePlayer() || !player->m_bEnemy() || !player->player_info.friendsID)
+                continue;
+            auto &data  = resolver_map[player->player_info.friendsID];
+            auto &angle = CE_VECTOR(player, netvar.m_angEyeAngles);
+            angle.x = data.new_angle.x;
+            angle.y = data.new_angle.y;
+        }
     }
 }
 
-void resolveEnt(int IDX, IClientEntity *entity)
+std::array<float, 5> yaw_resolves{ 0.0f, 180.0f, 90.0f, -90.0f, -180.0f };
+
+Vector resolveAngle(Vector angles, brutedata &brute)
+{
+    if (brute.brutenum % 2)
+    {
+        // Pitch resolver
+        if (angles.x >= 90)
+            angles.x = -89;
+        if (angles.x <= -90)
+            angles.x = 89;
+    }
+    while (angles.y > 180)
+        angles.y -= 360;
+
+    while (angles.y < -180)
+        angles.y += 360;
+
+    // Yaw Resolving
+    // Find out which angle we should try
+    int entry = (int) std::floor((brute.brutenum / 2.0f)) % yaw_resolves.size();
+    angles.y += yaw_resolves[entry];
+
+    while (angles.y > 180)
+        angles.y -= 360;
+
+    while (angles.y < -180)
+        angles.y += 360;
+
+    if (debug)
+        angles.y = 100;
+    return angles;
+}
+
+float resolveAngleYaw(float angle, brutedata &brute)
+{
+    brute.original_angle.y = angle;
+    while (angle > 180)
+        angle -= 360;
+
+    while (angle < -180)
+        angle += 360;
+
+    // Yaw Resolving
+    // Find out which angle we should try
+    int entry = (int) std::floor((brute.brutenum / 2.0f)) % yaw_resolves.size();
+    angle += yaw_resolves[entry];
+
+    while (angle > 180)
+        angle -= 360;
+
+    while (angle < -180)
+        angle += 360;
+
+    if (debug)
+        angle = 100;
+    brute.new_angle.y = angle;
+    return angle;
+}
+
+float resolveAnglePitch(float angle, brutedata &brute)
+{
+    brute.original_angle.x = angle;
+    if (brute.brutenum % 2)
+    {
+        // Pitch resolver
+        if (angle >= 90)
+            angle = -89;
+        if (angle <= -90)
+            angle = 89;
+    }
+    brute.new_angle.x = angle;
+    return angle;
+}
+
+void increaseBruteNum(int idx)
+{
+    auto ent        = ENTITY(idx);
+    if (CE_BAD(ent) || !ent->player_info.friendsID)
+        return;
+    auto &data = hacks::shared::anti_anti_aim::resolver_map[ent->player_info.friendsID];
+    if (data.hits_in_a_row >= 4)
+        data.hits_in_a_row = 2;
+    else if (data.hits_in_a_row >= 2)
+        data.hits_in_a_row = 0;
+    else
+    {
+        logging::Info("Brutenum for entity %i increased to %i", idx, data.brutenum++ + 1);
+        data.hits_in_a_row = 0;
+        auto &angle = CE_VECTOR(ent, netvar.m_angEyeAngles);
+        angle.x = resolveAnglePitch(data.original_angle.x, data);
+        angle.y = resolveAngleYaw(data.original_angle.y, data);
+        data.new_angle.x = angle.x;
+        data.new_angle.y = angle.y;
+    }
+}
+
+
+// gay garbage
+/*void resolveEnt(int IDX, IClientEntity *entity)
 {
     if (IDX == g_IEngine->GetLocalPlayer())
         return;
@@ -98,15 +207,23 @@ void resolveEnt(int IDX, IClientEntity *entity)
         const_cast<QAngle &>(entity->GetAbsAngles()) = VectorToQAngle(angles);
         netangles                                    = angles;
     }
+}*/
+
+void ResetPlayer(unsigned steamid)
+{
+    if (resolver_map.find(steamid) != resolver_map.end())
+        resolver_map.erase(steamid);
 }
 
 void ResetPlayer(int idx)
 {
-    g_Settings.brute.choke[idx]       = {};
-    g_Settings.brute.brutenum[idx]    = 0;
-    g_Settings.brute.last_angles[idx] = {};
-    g_Settings.brute.lastsimtime      = 0.0f;
+    CachedEntity *ent = ENTITY(idx);
+    if (!ent || CE_INVALID(ent) || !ent->player_info.friendsID)
+        return;
+    ResetPlayer(ent->player_info.friendsID);
 }
+
+/*
 class ResolverListener : public IGameEventListener
 {
 public:
@@ -131,5 +248,72 @@ public:
 };
 
 static ResolverListener listener;
-static InitRoutine init([]() { g_IGameEventManager->AddListener(&listener, false); });
+static InitRoutine init([]() { g_IGameEventManager->AddListener(&listener, false); });*/
+void PitchHook(const CRecvProxyData *pData, void *pStruct, void *pOut)
+{
+    logging::Info("Pitch hook called");
+    float *ang = (float *) pOut;
+    *ang       = pData->m_Value.m_Float;
+
+    auto client_ent   = (IClientEntity *) (pStruct);
+    CachedEntity *ent = ENTITY(client_ent->entindex());
+    if (CE_GOOD(ent))
+        *ang = resolveAnglePitch(pData->m_Value.m_Float, resolver_map[ent->player_info.friendsID]);
+}
+
+void YawHook(const CRecvProxyData *pData, void *pStruct, void *pOut)
+{
+    logging::Info("Yaw hook called");
+    float flYaw = pData->m_Value.m_Float;
+
+    float *flYaw_out = (float *) ((unsigned) pOut);
+
+    auto client_ent = (IClientEntity *) (pStruct);
+
+    CachedEntity *ent = ENTITY(client_ent->entindex());
+    if (CE_GOOD(ent))
+        *flYaw_out = resolveAngleYaw(flYaw, resolver_map[ent->player_info.friendsID]);
+}
+
+static InitRoutine init([]() {
+    auto pClass = g_IBaseClient->GetAllClasses();
+    while (pClass)
+    {
+        const char *pszName = pClass->m_pRecvTable->m_pNetTableName;
+        // "DT_TFPlayer", "tfnonlocaldata"
+        if (!strcmp(pszName, "DT_TFPlayer"))
+        {
+            for (int i = 0; i < pClass->m_pRecvTable->m_nProps; i++)
+            {
+                RecvPropRedef *pProp1 = (RecvPropRedef *) &(pClass->m_pRecvTable->m_pProps[i]);
+                if (!pProp1)
+                    continue;
+                const char *pszName2 = pProp1->m_pVarName;
+                if (!strcmp(pszName2, "tfnonlocaldata"))
+                    for (int j = 0; j < pProp1->m_pDataTable->m_nProps; j++)
+                    {
+                        RecvPropRedef *pProp2 = (RecvPropRedef *) &(pProp1->m_pDataTable->m_pProps[j]);
+                        if (!pProp2)
+                            continue;
+                        const char *name = pProp2->m_pVarName;
+                        logging::Info("tableing: %s %d", name, ((RecvProp *)pProp1)->GetNumElements());
+
+                        // Pitch Fix
+                        if (!strcmp(name, "m_angEyeAngles[0]"))
+                        {
+                            pProp2->m_ProxyFn = PitchHook;
+                        }
+
+                        // Yaw Fix
+                        if (!strcmp(name, "m_angEyeAngles[1]"))
+                        {
+                            logging::Info("Yaw Fix Applied");
+                            pProp2->m_ProxyFn = YawHook;
+                        }
+                    }
+            }
+        }
+        pClass = pClass->m_pNext;
+    }
+});
 } // namespace hacks::shared::anti_anti_aim

--- a/src/hacks/AutoReflect.cpp
+++ b/src/hacks/AutoReflect.cpp
@@ -119,7 +119,6 @@ void CreateMove()
         velocity::EstimateAbsVelocity(RAW_ENT(ent), velocity);
         // Predict a vector for where the projectile will be
         Vector predicted_proj = ent->m_vecOrigin() + (velocity * latency);
-        ;
 
         // Dont vischeck if ent is stickybomb or if dodgeball mode is enabled
         if (!IsEntStickyBomb(ent) && !dodgeball)

--- a/src/hacks/Thirdperson.cpp
+++ b/src/hacks/Thirdperson.cpp
@@ -34,8 +34,8 @@ void frameStageNotify()
     }
     if (real_angles && g_IInput->CAM_IsThirdPerson())
     {
-        CE_FLOAT(LOCAL_E, netvar.deadflag + 4) = g_Settings.brute.last_angles[LOCAL_E->m_IDX].x;
-        CE_FLOAT(LOCAL_E, netvar.deadflag + 8) = g_Settings.brute.last_angles[LOCAL_E->m_IDX].y;
+        CE_FLOAT(LOCAL_E, netvar.deadflag + 4) = LOCAL_E->m_vecAngle().x;
+        CE_FLOAT(LOCAL_E, netvar.deadflag + 8) = LOCAL_E->m_vecAngle().y;
     }
 }
 } // namespace hacks::tf::thirdperson

--- a/src/hooks/CreateMove.cpp
+++ b/src/hooks/CreateMove.cpp
@@ -270,10 +270,6 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
         firstcm = false;
     }
     g_Settings.bInvalid = false;
-    {
-        PROF_SECTION(CM_AAA);
-        hacks::shared::anti_anti_aim::createMove();
-    }
 
     if (CE_GOOD(g_pLocalPlayer->entity))
     {
@@ -397,8 +393,6 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
 
             ret = false;
         }
-        if (cmd && (cmd->buttons & IN_ATTACK || !(hacks::shared::antiaim::isEnabled() && (*fakelag_amount || (hacks::shared::antiaim::force_fakelag && hacks::shared::antiaim::isEnabled())) && *bSendPackets)))
-            g_Settings.brute.last_angles[LOCAL_E->m_IDX] = cmd->viewangles;
         for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
         {
 
@@ -411,11 +405,6 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
             INetChannel *ch = (INetChannel *) g_IEngine->GetNetChannelInfo();
             if (NET_FLOAT(RAW_ENT(ent), netvar.m_flSimulationTime) <= 1.5f)
                 continue;
-            float latency = hacks::shared::backtrack::getRealLatency();
-            g_Settings.brute.choke[i].push_back(NET_FLOAT(RAW_ENT(ent), netvar.m_flSimulationTime) == g_Settings.brute.lastsimtime);
-            g_Settings.brute.last_angles[ent->m_IDX] = NET_VECTOR(RAW_ENT(ent), netvar.m_angEyeAngles);
-            if (!g_Settings.brute.choke[i].empty() && g_Settings.brute.choke[i].size() > 20)
-                g_Settings.brute.choke[i].pop_front();
         }
     }
 

--- a/src/hooks/LevelInit.cpp
+++ b/src/hooks/LevelInit.cpp
@@ -11,6 +11,7 @@
 #include "HookedMethods.hpp"
 #include "MiscTemporary.hpp"
 #include "navparser.hpp"
+#include "AntiAntiAim.hpp"
 
 static settings::Boolean halloween_mode{ "misc.force-halloween", "false" };
 static settings::Int skybox_changer{ "misc.skybox-override", "0" };
@@ -50,8 +51,7 @@ DEFINE_HOOKED_METHOD(LevelInit, void, void *this_, const char *name)
     else if (holiday->m_nValue == 2)
         holiday->SetValue(0);
 #endif
-    for (int i = 0; i <= MAX_PLAYERS; i++)
-        g_Settings.brute.brutenum[i] = 0;
+    hacks::shared::anti_anti_aim::resolver_map.clear();
     g_IEngine->ClientCmd_Unrestricted("exec cat_matchexec");
     chat_stack::Reset();
     original::LevelInit(this_, name);

--- a/src/hooks/visual/FrameStageNotify.cpp
+++ b/src/hooks/visual/FrameStageNotify.cpp
@@ -9,6 +9,7 @@
 #include <hacks/Thirdperson.hpp>
 #include "HookedMethods.hpp"
 #include "hacks/Backtrack.hpp"
+#include "AntiAntiAim.hpp"
 
 static settings::Float nightmode{ "visual.night-mode", "0" };
 static settings::Boolean no_shake{ "visual.no-shake", "true" };
@@ -59,6 +60,10 @@ DEFINE_HOOKED_METHOD(FrameStageNotify, void, void *this_, ClientFrameStage_t sta
 
     if (!g_IEngine->IsInGame())
         g_Settings.bInvalid = true;
+    {
+        PROF_SECTION(FSN_antiantiaim);
+        hacks::shared::anti_anti_aim::frameStageNotify(stage);
+    }
     {
         PROF_SECTION(FSN_skinchanger);
         hacks::tf2::skinchanger::FrameStageNotify(stage);


### PR DESCRIPTION
* Almost completely rewrote antiantiaim.cpp
* Almost completely rewrote hitrate.cpp

New antiantiaim uses a combination of RecvTable proxies and FSN to resolve target players. The version in this commit is WIP and should not be used (yet). Hitrate.cpp has been rewritten to improve accuracy and code quality.

Todo:

- [ ] Unhook
- [ ] https://t.me/nullworks/178760
- [ ] https://t.me/nullworks/178820
- [ ] Make third person real angles work properly again