### PR TITLE
Added a few color options I forgot about + slight menu changes

### DIFF
--- a/data/menu/nullifiedcat/aimbot.xml
+++ b/data/menu/nullifiedcat/aimbot.xml
@@ -2,6 +2,7 @@
     <Box padding="12 6 6 6" width="content" height="content" name="Aimbot">
         <List width="150">
             <AutoVariable width="fill" target="aimbot.enable" label="Enable Aimbot"/>
+            <AutoVariable width="fill" target="aimbot.aimkey.button" label="Aim Key"/>
             <LabeledObject width="fill" label="Aim Key Mode">
                 <Select target="aimbot.aimkey.mode">
                     <Option name="Disable" value="0"/>
@@ -10,12 +11,11 @@
                     <Option name="Toggle" value="3"/>
                 </Select>
             </LabeledObject>
-            <AutoVariable width="fill" target="aimbot.aimkey.button" label="Aim Key"/>
             <AutoVariable width="fill" target="aimbot.silent" label="Silent"/>
-            <AutoVariable width="fill" target="aimbot.fov-circle.enable" label="FOV Circle"/>
+            <AutoVariable width="fill" target="aimbot.slow" label="Slow Aimbot" min="0" max="30"/>
             <AutoVariable width="fill" target="aimbot.fov" label="FOV"/>
-            <AutoVariable width="fill" target="aimbot.fov-circle.opacity" label="FOV Opacity"/>
-            <AutoVariable width="fill" target="aimbot.slow" label="Slow Aimbot"/>
+            <AutoVariable width="fill" target="aimbot.fov-circle.enable" label="FOV Circle"/>
+            <AutoVariable width="fill" target="aimbot.fov-circle.opacity" label="FOV Opacity" min="0" max="1"/>
             <AutoVariable width="fill" target="aimbot.can-shoot-only" label="Only Shoot When Able"/>
             <AutoVariable width="fill" target="aimbot.miss-chance" label="Miss chance"/>
             <AutoVariable width="fill" target="aimbot.extrapolate" label="Extrapolate"/>

--- a/data/menu/nullifiedcat/antiaim.xml
+++ b/data/menu/nullifiedcat/antiaim.xml
@@ -5,7 +5,7 @@
             <AutoVariable width="fill" target="antiaim.draw-fakes" label="Draw fakes"/>
             <AutoVariable width="fill" target="antiaim.crouch" label="Fake crouch"/>
             <AutoVariable width="fill" target="antiaim.no-clamp" label="No clamping"/>
-            <AutoVariable width="fill" target="misc.fakelag" label="Fakelag" min="0" max="14"/>
+            <AutoVariable width="fill" target="misc.fakelag" label="Fakelag" min="0" max="15"/>
             <AutoVariable width="fill" target="antiaim.spin-speed" label="Spin speed" min="-45" max="45"/>
             <AutoVariable width="fill" target="antiaim.roll" label="Roll"/>
             <AutoVariable width="fill" target="antiaim.pitch.static" label="Custom Pitch"/>

--- a/data/menu/nullifiedcat/antiaim.xml
+++ b/data/menu/nullifiedcat/antiaim.xml
@@ -5,14 +5,15 @@
             <AutoVariable width="fill" target="antiaim.draw-fakes" label="Draw fakes"/>
             <AutoVariable width="fill" target="antiaim.crouch" label="Fake crouch"/>
             <AutoVariable width="fill" target="antiaim.no-clamp" label="No clamping"/>
-            <AutoVariable width="fill" target="antiaim.spin-speed" label="Spin speed"/>
+            <AutoVariable width="fill" target="misc.fakelag" label="Fakelag" min="0" max="14"/>
+            <AutoVariable width="fill" target="antiaim.spin-speed" label="Spin speed" min="-45" max="45"/>
             <AutoVariable width="fill" target="antiaim.roll" label="Roll"/>
-            <AutoVariable width="fill" target="antiaim.pitch.static" label="Static pitch"/>
-	    <AutoVariable width="fill" target="misc.fakelag" label="Fakelag"/>
+            <AutoVariable width="fill" target="antiaim.pitch.static" label="Custom Pitch"/>
+            <AutoVariable width="fill" target="antiaim.yaw.static" label="Custom Yaw"/>
             <LabeledObject width="fill" label="Pitch mode">
                 <Select target="antiaim.pitch.mode">
                     <Option name="Disable" value="0"/>
-                    <Option name="Static" value="1"/>
+                    <Option name="Custom" value="1"/>
                     <Option name="Jitter" value="2"/>
                     <Option name="Random" value="3"/>
                     <Option name="Flip" value="4"/>
@@ -25,16 +26,15 @@
                     <Option name="Heck" value="11"/>
                 </Select>
             </LabeledObject>
-            <AutoVariable width="fill" target="antiaim.yaw.static" label="Static yaw"/>
             <LabeledObject width="fill" label="Yaw mode">
                 <Select target="antiaim.yaw.mode">
                     <Option name="Disable" value="0"/>
-                    <Option name="Static" value="1"/>
+                    <Option name="Custom" value="1"/>
+                    <Option name="Custom Offset" value="6"/>
                     <Option name="Jitter" value="2"/>
                     <Option name="BigRandom" value="3"/>
                     <Option name="Random" value="4"/>
                     <Option name="Spin" value="5"/>
-                    <Option name="Offset" value="6"/>
                     <Option name="Edge" value="7"/>
                     <Option name="Heck" value="8"/>
                     <Option name="Fake" value="9"/>

--- a/data/menu/nullifiedcat/visuals/uicolors.xml
+++ b/data/menu/nullifiedcat/visuals/uicolors.xml
@@ -8,61 +8,64 @@
     </Box>
     <Box padding="12 6 6 6" width="content" height="content" name="Window Titlebars" y="73">
         <List width="150">
-            <AutoVariable width="fill" target="zk.style.window-header.color.border.active" label="Border"/>
+            <AutoVariable width="fill" target="zk.style.window-header.color.border.active" label="Active Border"/>
+            <AutoVariable width="fill" target="zk.style.window-header.color.border.inactive" label="Inactive Border"/>
             <AutoVariable width="fill" target="zk.style.window-header.color.background.active" label="Active Background"/>
             <AutoVariable width="fill" target="zk.style.window-header.color.background.inactive" label="Inactive Background"/>
         </List>
     </Box>
-    <Box padding="12 6 6 6" width="content" height="content" name="Window Close button" y="146">
+    <Box padding="12 6 6 6" width="content" height="content" name="Window Close button" y="164">
         <List width="150">
             <AutoVariable width="fill" target="zk.style.window-close-button.color.border" label="Border"/>
-            <AutoVariable width="fill" target="zk.style.window-close-button.color.background-hover" label="Hover Background"/>
         </List>
     </Box>
     <Box padding="12 6 6 6" width="content" height="content" name="Other Container elements" y="203">
         <List width="150">
             <AutoVariable width="fill" target="zk.style.box.color.border" label="Box Border"/>
-            <AutoVariable width="fill" target="zk.style.tab-selection.color.border" label="Tab Selection Border"/>
             <AutoVariable width="fill" target="zk.style.input.color.border" label="Color Picker Border"/>
             <AutoVariable width="fill" target="zk.style.modal-container.color.border" label="Modal Border"/>
             <AutoVariable width="fill" target="zk.style.modal-container.color.background" label="Modal Background"/>
             <AutoVariable width="fill" target="zk.style.table.color.border" label="Table"/>
+            <AutoVariable width="fill" target="zk.style.tab-button.color.selected.underline" label="Tab Active Underline"/>
+            <AutoVariable width="fill" target="zk.style.tab-button.color.hover.underline" label="Tab Hover Underline"/>
+            <AutoVariable width="fill" target="zk.style.menu.color.text" label="Text"/>
         </List>
     </Box>
     <Box padding="12 6 6 6" width="content" height="content" name="List Select" x="170">
-        <List width="120">
+        <List width="150">
             <AutoVariable width="fill" target="zk.style.input.select.border" label="Border"/>
+            <AutoVariable width="fill" target="zk.style.option.color.hover" label="Hover Background"/>
         </List>
     </Box>
-    <Box padding="12 6 6 6" width="content" height="content" name="Text Input" x="170" y="38">
-        <List width="120">
+    <Box padding="12 6 6 6" width="content" height="content" name="Text Input" x="170" y="56">
+        <List width="150">
             <AutoVariable width="fill" target="zk.style.input.text.color.border.active" label="Active Border"/>
             <AutoVariable width="fill" target="zk.style.input.text.color.border.inactive" label="Inactive Border"/>
             <AutoVariable width="fill" target="zk.style.input.text.color.text.active" label="Active Text"/>
             <AutoVariable width="fill" target="zk.style.input.text.color.text.inactive" label="Inactive Text"/>
         </List>
     </Box>
-    <Box padding="12 6 6 6" width="content" height="content" name="Key Input" x="170" y="128">
-        <List width="120">
+    <Box padding="12 6 6 6" width="content" height="content" name="Key Input" x="170" y="146">
+        <List width="150">
             <AutoVariable width="fill" target="zk.style.input.key.color.border" label="Border"/>
             <AutoVariable width="fill" target="zk.style.input.key.color.background.capturing" label="Background"/>
         </List>
     </Box>
-    <Box padding="12 6 6 6" width="content" height="content" name="Slider" x="170" y="184">
-        <List width="120">
+    <Box padding="12 6 6 6" width="content" height="content" name="Slider" x="170" y="202">
+        <List width="150">
             <AutoVariable width="fill" target="zk.style.input.slider.color.handle_border" label="Handle Border"/>
             <AutoVariable width="fill" target="zk.style.input.slider.color.handle_body" label="Handle Body"/>
             <AutoVariable width="fill" target="zk.style.input.slider.color.bar" label="Bar"/>
         </List>
     </Box>
-    <Box padding="12 6 6 6" width="content" height="content" name="Checkbox" x="170" y="257">
-        <List width="120">
+    <Box padding="12 6 6 6" width="content" height="content" name="Checkbox" x="170" y="275">
+        <List width="150">
             <AutoVariable width="fill" target="zk.style.checkbox.color.border" label="Border"/>
             <AutoVariable width="fill" target="zk.style.checkbox.color.checked" label="Checked"/>
             <AutoVariable width="fill" target="zk.style.checkbox.color.hover" label="Hover"/>
         </List>
     </Box>
-    <Box padding="12 6 6 6" width="content" height="content" name="Playerlist" x="310">
+    <Box padding="12 6 6 6" width="content" height="content" name="Playerlist" x="340">
         <List width="150">
             <AutoVariable width="fill" target="zk.style.player-list.team.red" label="RED Team"/>
             <AutoVariable width="fill" target="zk.style.player-list.team.red-dead" label="RED Team dead"/>
@@ -70,19 +73,28 @@
             <AutoVariable width="fill" target="zk.style.player-list.team.blue-dead" label="BLU Team dead"/>
         </List>
     </Box>
-    <Box padding="12 6 6 6" width="content" height="content" name="Taskbar" x="310" y="91">
+    <Box padding="12 6 6 6" width="content" height="content" name="Taskbar" x="340" y="91">
         <List width="150">
             <AutoVariable width="fill" target="zk.style.taskbar.color.border" label="Border"/>
             <AutoVariable width="fill" target="zk.style.taskbar.color.background" label="Background"/>
         </List>
     </Box>
-    <Box padding="12 6 6 6" width="content" height="content" name="Task" x="310" y="148">
+    <Box padding="12 6 6 6" width="content" height="content" name="Task" x="340" y="148">
         <List width="150">
             <AutoVariable width="fill" target="zk.style.task.color.border" label="Border"/>
             <AutoVariable width="fill" target="zk.style.task.color.background.hover" label="Hover"/>
             <AutoVariable width="fill" target="zk.style.task.color.text.focused" label="Text Focused"/>
             <AutoVariable width="fill" target="zk.style.task.color.text.open" label="Text Open"/>
             <AutoVariable width="fill" target="zk.style.task.color.text.closed" label="Text Closed"/>
+        </List>
+    </Box>
+    <Box padding="12 6 6 6" width="content" height="content" name="Tabs" x="340" y="256">
+        <List width="150">
+            <AutoVariable width="fill" target="zk.style.tab-selection.color.border" label="Tab Selection Border"/>
+            <AutoVariable width="fill" target="zk.style.tab-button.color.separator" label="Tab Separator"/>
+            <AutoVariable width="fill" target="zk.style.tab-button.color.selected.background" label="Active Background"/>
+            <AutoVariable width="fill" target="zk.style.tab-button.color.text.selected" label="Active Text"/>
+            <AutoVariable width="fill" target="zk.style.tab-button.color.text.inactive" label="Text"/>
         </List>
     </Box>
 </Tab>


### PR DESCRIPTION
The UI Colors tab with the added options
  
![Screenshot from 2019-10-25 20-17-23](https://user-images.githubusercontent.com/32032674/67592282-fecc3a00-f767-11e9-8b82-6f3e4d48d36f.png)
  
Also changed Fake Lag and Spin Speed to be a slider along with moving some things around in the HvH tab for simplicity's sake.  
* Spin Speed min/max is -45 to 45 as above/below is quite literally just Random which is already an option.
* Fake Lag min/max is 0 to 14. Above 14 causes actual lag.
   
![Screenshot from 2019-10-25 20-40-40](https://user-images.githubusercontent.com/32032674/67592363-2d4a1500-f768-11e9-8c57-f26cc9691494.png)
  
As well as making FOV Opacity and Slow Aimbot into sliders and moving some things to be more consistent.
* Slow Aimbot min/max is 0 to 30. More than 30 is just memeing and doesn't help you aim better at all, though I'd say 30 is already going into meme territory due to how slow it is.
  
![Screenshot from 2019-10-25 20-40-20](https://user-images.githubusercontent.com/32032674/67592505-9598f680-f768-11e9-90eb-800fd6226ae6.png)