### PR TITLE
Update scripts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "ucccccp"]
 	path = external/ucccccp
 	url = https://github.com/nullworks/ucccccp.git
-[submodule "external/co-library"]
-	path = external/co-library
-	url = https://github.com/nullworks/co-library.git
 [submodule "external/MicroPather"]
 	path = external/MicroPather
 	url = https://github.com/nullworks/MicroPather

--- a/install-all
+++ b/install-all
@@ -5,23 +5,6 @@ RUNCMD="sudo -u $RUNUSER"
 
 set -e
 
-# install all dependencies
-./scripts/dependencycheck
-
-#
-# Update cathook
-#
-if [ ! -d "./.git" ]; then
-    $RUNCMD git init
-    $RUNCMD git remote add origin https://github.com/nullworks/cathook
-fi
-
-#
-# Set config version for update script
-#
-
-$RUNCMD bash -c ". ./scripts/config.shlib; cfg_write ./scripts/updater-preferences version 2"
-
 #
 # Build cathook
 #

--- a/scripts/dependencycheck
+++ b/scripts/dependencycheck
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 
+# $1 Git only
+
+GIT=${1:-false}
+
 arch_packages=(git boost cmake make gcc gdb lib32-sdl2 lib32-glew lib32-freetype2 rsync lib32-libglvnd dialog)
 ubuntu_packages=(software-properties-common build-essential git g++ g++-multilib libboost-all-dev gdb libsdl2-dev:i386 libglew-dev:i386 libfreetype6-dev:i386 cmake dialog rsync)
 fedora_packages=(cmake dialog make gcc-c++ glibc-devel.i686 freetype-devel.i686 SDL2-devel.i686 glew-devel.i686 boost-devel.i686 rsync gdb git)
+
+# Check if we should only install git
+if [ "$GIT" == true ]; then
+    arch_packages=(git)
+    ubuntu_packages=(git)
+    fedora_packages=(git)
+fi
 
 function requestPermissions {
     string=$@

--- a/scripts/migrations
+++ b/scripts/migrations
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-# $3 Init
+# $1 TUI 
+# $2 INIT
+# $3 Pre update
+
+CURR_VERSION=3
+
+TUI=${1:-false}
+INIT=${2:-false}
+PRE_UPDATE=${3:-false}
 
 set -e
 
@@ -17,26 +25,62 @@ if [ ! -t 0 ]; then
 fi
 
 #
-# Init goes here
+# Git check
 #
-
-if [ "$3" == true ]; then
-    cfg_write $configfile update_channel stable
-    cfg_write $configfile version 3
+if [ "$PRE_UPDATE" == "true" ]; then
+if [ ! -x "$(command -v git)" ]; then
+    # install only git
+    echo git not installed!
+    ./scripts/dependencycheck true
+fi
+if [ ! -d "./.git" ]; then
+    git init
+    git remote add origin https://github.com/nullworks/cathook
+fi
 fi
 
-version="$(cfg_read $configfile version)"
-
+#
+# Init goes here
+#
+function init() {
+    if [ "$INIT" == true ]; then
+        cfg_write $configfile update_channel stable
+        cfg_write $configfile version $CURR_VERSION
+    fi
+}
 
 #
 # Migrations go here
 #
-
-exists=true
-
-if [ "$version" == 1 ] || [ "$version" == 2 ]; then
-    cfg_write $configfile version 3
-    if [ -d "./build/CMakeFiles/cathook.dir" ]; then
-        rm -r ./build/CMakeFiles/cathook.dir
+function migrations() {
+    exists=true
+    cfg_haskey $configfile version || exists=false
+    if [ "$exists" == true ]; then
+        version="$(cfg_read $configfile version)"
+    else
+        # No version string. Nothing we can do.
+        return 0
     fi
+    
+    if (( $version > $CURR_VERSION )); then
+        cfg_write $configfile version $CURR_VERSION
+    fi
+
+    if [ "$version" == 1 ] || [ "$version" == 2 ]; then
+        cfg_write $configfile version 3
+        if [ -d "./build/CMakeFiles/cathook.dir" ]; then
+            rm -r ./build/CMakeFiles/cathook.dir
+        fi
+    fi
+}
+
+if [ "$PRE_UPDATE" == "true" ] && [ "$INIT" == "true" ]; then
+    # Our job is done here
+    exit
+fi
+
+if [ "$INIT" == true ]; then
+    init
+else
+    migrations
 fi

--- a/scripts/migrations
+++ b/scripts/migrations
@@ -25,7 +25,7 @@ if [ ! -t 0 ]; then
 fi
 
 #
-# Git check
+# Git check, migrate users from .zip to git repos
 #
 if [ "$PRE_UPDATE" == "true" ]; then
 if [ ! -x "$(command -v git)" ]; then
@@ -66,6 +66,7 @@ function migrations() {
         cfg_write $configfile version $CURR_VERSION
     fi
 
+    # Hack to fix compile error between version 1 and version 3. Version 2 was set on installs on accident.
     if [ "$version" == 1 ] || [ "$version" == 2 ]; then
         cfg_write $configfile version 3
         if [ -d "./build/CMakeFiles/cathook.dir" ]; then
@@ -75,7 +76,7 @@ function migrations() {
 }
 
 if [ "$PRE_UPDATE" == "true" ] && [ "$INIT" == "true" ]; then
-    # Our job is done here
+    # Our job is done here. We dont want to set a config version here yet.
     exit
 fi
 

--- a/scripts/updater
+++ b/scripts/updater
@@ -12,6 +12,7 @@ set -e
 
 configfile="./scripts/updater-preferences"
 
+# Verify that we aren't root
 if [ $(id -u) -eq 0 ]; then
     echo -e "\033[1;33m \n \nThis script must'nt be run as root!\n\033[0m"
     exit 1
@@ -29,6 +30,7 @@ echo $$ > ${LOCKFILE}
 
 . ./scripts/config.shlib
 
+# If the config file doesn't exist, create it
 if [ ! -e ${configfile} ]; then
     touch ${configfile}
 fi
@@ -49,7 +51,7 @@ if [ ! -x "$(command -v dialog)" ] || [ "$tui" == false ]; then
     fi
 fi
 
-# Run migrations 
+# Run migrations if not a developer
 exists=true
 cfg_haskey $configfile update_channel || exists=false
 if [ "$exists" == true ]; then
@@ -59,6 +61,7 @@ if [ "$update_channel" != "developer" ]; then
     ./scripts/migrations $tui $INIT true || exit 1
 fi
 
+# Ask the user if they want to enable the auto updater
 exists=true
 cfg_haskey $configfile autoupdater || exists=false
 if [ "$dialog" == true ] && [ "$exists" == false ]; then
@@ -74,6 +77,7 @@ if [ "$dialog" == true ] && [ "$exists" == false ]; then
     cfg_write $configfile autoupdater $value
 fi
 
+# Send notice about auto updater, terminate script if its not enabled
 exists=true
 cfg_haskey $configfile autoupdater || exists=false
 if [ "$AUTO_UPDATER_ENABLED" == "true" ]; then
@@ -112,7 +116,7 @@ function performupdate() {
             value=true
             dialog --keep-tite --title "Updater"  --yesno "Unknown update channel or version. Restore to stable update channel and reset version?" 10 25 || value=false
             if [ "$value" == true ]; then
-                # force init
+                # force reinit
                 ./scripts/migrations $tui true false || exit 1
             fi
         fi
@@ -127,14 +131,15 @@ function performupdate() {
     # Check if all required packages are installed
     ./scripts/dependencycheck
     
-    #submodules
+    # Submodules
     if [ "$update_channel" == "developer" ]; then
         git submodule update --init --recursive
     else
-        git submodule sync
+        git submodule sync > /dev/null
         git submodule update --depth 1 --init --recursive
     fi
 
+    # Make sure that the auto updater only uses 1 core for compiling
     proccount=$(grep -c '^processor' /proc/cpuinfo)
     if [ "$AUTOUPDATER" == true ]; then
         proccount=1
@@ -143,9 +148,10 @@ function performupdate() {
     #Create build folder in case it doesn't exist
     mkdir -p ./build
     # Update cathook
-    cd build && cmake .. && cmake --build . --target cathook -- -j$proccount || { echo -e "\033[1;31m \n \nFailed to compile cathook\n\033[0m"; exit 1; }
+    pushd build && cmake .. && cmake --build . --target cathook -- -j$proccount || { echo -e "\033[1;31m \n \nFailed to compile cathook\n\033[0m"; exit 1; }
     # Update data
     cmake --build . --target data || { echo -e "\033[1;31m\nFailed to update /opt/cathook/data directory! Trying with root rights!\n\033[0m"; sudo cmake --build . --target data || { echo -e "\033[1;31m\nFailed to update /opt/cathook/data directory\n\033[0m"; exit 1; } }
+    popd
     echo -e "\n\033[1;34mCathook updated successfully\n\033[0m"
     rm -f ${LOCKFILE}
 }

--- a/scripts/updater
+++ b/scripts/updater
@@ -4,9 +4,9 @@
 # $2 Disable TUI
 # $3 Init
 
-ARG1=${1:-false}
-ARG2=${2:-false}
-ARG3=${3:-false}
+AUTO_UPDATER_ENABLED=${1:-false}
+DISABLE_TUI=${2:-false}
+INIT=${3:-false}
 
 set -e
 
@@ -29,34 +29,39 @@ echo $$ > ${LOCKFILE}
 
 . ./scripts/config.shlib
 
+if [ ! -e ${configfile} ]; then
+    touch ${configfile}
+fi
+
+#Check if TUI is available
+tui=true
+dialog=true
+if [ ! -t 0 ]; then
+    tui=false
+fi
+if [ "$DISABLE_TUI" == "true" ]; then
+    tui=false
+fi
+if [ ! -x "$(command -v dialog)" ] || [ "$tui" == false ]; then
+    dialog=false
+    if [ "$tui" == true ]; then
+        echo -e "\033[1;31mTerminal UI NOT supported! Install \"dialog\"! \033[0m"
+    fi
+fi
+
 # Run migrations 
 exists=true
 cfg_haskey $configfile update_channel || exists=false
 if [ "$exists" == true ]; then
     update_channel="$(cfg_read $configfile update_channel)"
 fi
-if [ "$update_channel" != "developer" ] && [ "$ARG3" == false ]; then
-    ./scripts/migrations $ARG1 $ARG2 false || exit 0
-fi
-
-# Check if all required packages are installed
-./scripts/dependencycheck
-
-tui=true
-if [ ! -t 0 ]; then
-    tui=false
-fi
-if [ "$ARG2" == "true" ]; then
-    tui=false
-fi
-if [ ! -x "$(command -v dialog)" ] && [ "$tui" == true ]; then
-    tui=false
-    echo -e "\033[1;31mTerminal UI NOT supported! Install \"dialog\"! \033[0m"
+if [ "$update_channel" != "developer" ]; then
+    ./scripts/migrations $tui $INIT true || exit 1
 fi
 
 exists=true
 cfg_haskey $configfile autoupdater || exists=false
-if [ "$tui" == true ] && [ "$exists" == false ]; then
+if [ "$dialog" == true ] && [ "$exists" == false ]; then
     value=true
     response=255
     while [ "$response" != 0 ] && [ "$response" != 1 ]; do
@@ -71,7 +76,7 @@ fi
 
 exists=true
 cfg_haskey $configfile autoupdater || exists=false
-if [ "$ARG1" == "true" ]; then
+if [ "$AUTO_UPDATER_ENABLED" == "true" ]; then
     if [ $exists == false ] || [ "$(cfg_read $configfile autoupdater)" == false ]; then
         exit 0;
     fi
@@ -82,11 +87,18 @@ fi
 
 function performupdate() {
     # If init, then update_channel isn't set yet. Assume stable.
-    if [ "$ARG3" == true ]; then
+    if [ "$INIT" == true ]; then
         update_channel="stable"
     else
         #get update channel from config
-        update_channel="$(cfg_read $configfile update_channel)"
+        exists=true
+        cfg_haskey $configfile autoupdater || exists=false
+        cfg_haskey $configfile version || exists=false
+        if [ "$exists" ==  true ]; then
+            update_channel="$(cfg_read $configfile update_channel)"
+        else
+            update_channel="invalid"
+        fi
     fi
     
     if [ "$update_channel" == "stable" ]; then
@@ -96,11 +108,12 @@ function performupdate() {
     elif [ "$update_channel" == "developer" ]; then
         echo -e "\033[1;33m\nWarning! Running in developer mode! Expect issues!\n\033[0m" && git pull origin || { echo -e "\033[1;31m\n\nFailed to pull from github!\n\033[0m"; exit 1; }
     else
-        if [ "$tui" == true ]; then
+        if [ "$dialog" == true ]; then
             value=true
-            dialog --keep-tite --title "Updater"  --yesno "Unknown update channel. Restore to stable update channel?" 10 25 || value=false
+            dialog --keep-tite --title "Updater"  --yesno "Unknown update channel or version. Restore to stable update channel and reset version?" 10 25 || value=false
             if [ "$value" == true ]; then
-                cfg_write $configfile update_channel stable
+                # force init
+                ./scripts/migrations $tui true false || exit 1
             fi
         fi
         exit 1
@@ -108,8 +121,11 @@ function performupdate() {
     
     # Run migrations 
     if [ "$update_channel" != "developer" ]; then
-        ./scripts/migrations $ARG1 $ARG2 $ARG3 || exit 0
+        ./scripts/migrations $tui $INIT false || exit 1
     fi
+    
+    # Check if all required packages are installed
+    ./scripts/dependencycheck
     
     #submodules
     if [ "$update_channel" == "developer" ]; then


### PR DESCRIPTION
- Install git independently of other packages (Stable may have other dependencies than master. Also allows us to remove some package install hacks from nullworks/One-in-all-cathook-install)
- Improve the update scripts capabilities to recover a bad repo