### PR TITLE
AutoReflect support for toggling several different projectile types

### DIFF
--- a/data/menu/nullifiedcat/trigger/autopyro.xml
+++ b/data/menu/nullifiedcat/trigger/autopyro.xml
@@ -1,13 +1,14 @@
 <Tab name="Auto Pyro" padding="4 4 4 4">
 	<Box padding="12 6 6 6" width="content" height="content" name="Auto Reflect">
-		<List width="content">
+		<List width="202">
 			<AutoVariable width="fill" target="autoreflect.enable" label="Enable Auto Reflect"/>
 			<AutoVariable width="fill" target="autoreflect.button" label="Reflect Button"/>
 			<AutoVariable width="fill" target="autoreflect.idle-only" label="Only Reflect When Able"/>
 			<AutoVariable width="fill" target="autoreflect.teammate" label="Teammate Projectiles"/>
 			<AutoVariable width="fill" target="autoreflect.dodgeball" label="Dodgeball Mode"/>
+			<AutoVariable width="fill" target="autoreflect.legit" label="Legit Mode" tooltip="Don't move the mouse to reflect. Spectator safe."/>
 		</List>
-		<Box padding="12 6 6 6" name="Projectiles" width="content" height="content" y="80">
+		<Box padding="12 6 6 6" name="Projectiles" width="content" height="content" y="100">
 			<Box padding="12 6 6 6" name="Big" width="content" height="content">
 				<List width="95">
 					<AutoVariable width="fill" target="autoreflect.rockets" label="Rockets"/>
@@ -21,12 +22,12 @@
 				<List width="85">
 					<AutoVariable width="fill" target="autoreflect.flares" label="Flares"/>
 					<AutoVariable width="fill" target="autoreflect.arrows" label="Arrows"/>
-					<AutoVariable width="fill" target="autoreflect.balls" label="Balls"/>
 					<AutoVariable width="fill" target="autoreflect.jars" label="Jars"/>
 					<AutoVariable width="fill" target="autoreflect.healingbolts" label="Healing Bolts"/>
 					<AutoVariable width="fill" target="autoreflect.cleavers" label="Cleavers"/>
 				</List>
 			</Box>
+			<AutoVariable width="196" y="95" target="autoreflect.default" label="Default" tooltip="If a projectile is not known, should Autoreflect still try to reflect it?"/>
 		</Box>
 	</Box>
 	<Box padding="12 6 6 6" width="content" height="content" name="Auto Detonator" x="235">

--- a/data/menu/nullifiedcat/trigger/autopyro.xml
+++ b/data/menu/nullifiedcat/trigger/autopyro.xml
@@ -1,22 +1,38 @@
 <Tab name="Auto Pyro" padding="4 4 4 4">
-    <Box padding="12 6 6 6" width="content" height="content" name="Auto Reflect">
-        <List width="150">
-            <AutoVariable width="fill" target="autoreflect.enable" label="Enable Auto Reflect"/>
-            <AutoVariable width="fill" target="autoreflect.button" label="Reflect Button"/>
-	    <AutoVariable width="fill" target="autoreflect.legit" label="Enable Legit Mode"/>
-            <AutoVariable width="fill" target="autoreflect.fov" label="FOV"/>
-            <!-- <AutoVariable width="fill" target="autoreflect.draw-fov" label="draw FOV"/> -->
-            <!-- <AutoVariable width="fill" target="autoreflect.draw-fov-opacity" label="FOV opacity"/> -->
-            <AutoVariable width="fill" target="autoreflect.idle-only" label="Only Reflect When Able"/>
-            <AutoVariable width="fill" target="autoreflect.dodgeball" label="Dodgeball Mode"/>
-            <AutoVariable width="fill" target="autoreflect.stickies" label="Stickies"/>
-            <AutoVariable width="fill" target="autoreflect.teammate" label="Teammate Projectiles"/>
-        </List>
-    </Box>
-    <Box padding="12 6 6 6" width="content" height="content" name="Auto Detonator" x="165">
-        <List width="150">
-            <AutoVariable width="fill" target="auto-detonator.enable" label="Enable Auto Detonator"/>
-            <AutoVariable width="fill" target="auto-detonator.ignore-cloaked" label="Ignore Cloaked"/>
-        </List>
-    </Box>
+	<Box padding="12 6 6 6" width="content" height="content" name="Auto Reflect">
+		<List width="content">
+			<AutoVariable width="fill" target="autoreflect.enable" label="Enable Auto Reflect"/>
+			<AutoVariable width="fill" target="autoreflect.button" label="Reflect Button"/>
+			<AutoVariable width="fill" target="autoreflect.idle-only" label="Only Reflect When Able"/>
+			<AutoVariable width="fill" target="autoreflect.teammate" label="Teammate Projectiles"/>
+			<AutoVariable width="fill" target="autoreflect.dodgeball" label="Dodgeball Mode"/>
+		</List>
+		<Box padding="12 6 6 6" name="Projectiles" width="content" height="content" y="80">
+			<Box padding="12 6 6 6" name="Big" width="content" height="content">
+				<List width="95">
+					<AutoVariable width="fill" target="autoreflect.rockets" label="Rockets"/>
+					<AutoVariable width="fill" target="autoreflect.pipes" label="Pipes"/>
+					<AutoVariable width="fill" target="autoreflect.stickies" label="Stickies"/>
+					<AutoVariable width="fill" target="autoreflect.sentryrockets" label="Sentry Rockets"/>
+				</List>
+			</Box>
+
+			<Box padding="12 6 6 6" name="Small" width="content" height="content" x="105">
+				<List width="85">
+					<AutoVariable width="fill" target="autoreflect.flares" label="Flares"/>
+					<AutoVariable width="fill" target="autoreflect.arrows" label="Arrows"/>
+					<AutoVariable width="fill" target="autoreflect.balls" label="Balls"/>
+					<AutoVariable width="fill" target="autoreflect.jars" label="Jars"/>
+					<AutoVariable width="fill" target="autoreflect.healingbolts" label="Healing Bolts"/>
+					<AutoVariable width="fill" target="autoreflect.cleavers" label="Cleavers"/>
+				</List>
+			</Box>
+		</Box>
+	</Box>
+	<Box padding="12 6 6 6" width="content" height="content" name="Auto Detonator" x="235">
+		<List width="150">
+			<AutoVariable width="fill" target="auto-detonator.enable" label="Enable Auto Detonator"/>
+			<AutoVariable width="fill" target="auto-detonator.ignore-cloaked" label="Ignore Cloaked"/>
+		</List>
+	</Box>
 </Tab>

--- a/src/hacks/AutoReflect.cpp
+++ b/src/hacks/AutoReflect.cpp
@@ -16,25 +16,24 @@ static settings::Boolean legit{ "autoreflect.legit", "false" };
 static settings::Boolean dodgeball{ "autoreflect.dodgeball", "false" };
 static settings::Button blastkey{ "autoreflect.button", "<null>" };
 
+static settings::Boolean proj_default{ "autoreflect.default", "false" };
 static settings::Boolean stickies{ "autoreflect.stickies", "true" };
 static settings::Boolean pipes{ "autoreflect.pipes", "true" };
-static settings::Boolean flares{ "autoreflect.flares", "false"};
-static settings::Boolean arrows{ "autoreflect.arrows", "false"};
-static settings::Boolean jars{ "autoreflect.jars", "false"};
-static settings::Boolean healingbolts{ "autoreflect.healingbolts", "false"};
-static settings::Boolean rockets{ "autoreflect.rockets", "true"};
-static settings::Boolean sentryrockets{ "autoreflect.sentryrockets", "true"};
-static settings::Boolean cleavers{ "autoreflect.cleavers", "false"};
-static settings::Boolean teammates{ "autoreflect.teammate", "true" };
+static settings::Boolean flares{ "autoreflect.flares", "false" };
+static settings::Boolean arrows{ "autoreflect.arrows", "false" };
+static settings::Boolean jars{ "autoreflect.jars", "false" };
+static settings::Boolean healingbolts{ "autoreflect.healingbolts", "false" };
+static settings::Boolean rockets{ "autoreflect.rockets", "true" };
+static settings::Boolean sentryrockets{ "autoreflect.sentryrockets", "true" };
+static settings::Boolean cleavers{ "autoreflect.cleavers", "false" };
+static settings::Boolean teammates{ "autoreflect.teammate", "false" };
 
 static settings::Float fov{ "autoreflect.fov", "85" };
-
 
 #if ENABLE_VISUALS
 static settings::Boolean fov_draw{ "autoreflect.draw-fov", "false" };
 static settings::Float fovcircle_opacity{ "autoreflect.draw-fov-opacity", "0.7" };
 #endif
-
 
 // Function to determine whether an ent is good to reflect
 static bool ShouldReflect(CachedEntity *ent)
@@ -61,43 +60,41 @@ static bool ShouldReflect(CachedEntity *ent)
             return false;
     }
 
-
-
     // Checks if the projectile is x and if the user settings allow it to be reflected
     // If not, returns false
 
-    if (!stickies && ent->m_iClassID() == CL_CLASS(CTFGrenadePipebombProjectile))
-        //Checks the demoguy projectile type (both stickies and pipes are combined under PipeBombProjectile)
+    if (ent->m_iClassID() == CL_CLASS(CTFGrenadePipebombProjectile))
+    {
+        // Checks the demoman projectile type (both stickies and pipes are combined under PipeBombProjectile)
         if (CE_INT(ent, netvar.iPipeType) == 1)
-            return false;
-
-    if (!pipes && ent->m_iClassID() == CL_CLASS(CTFGrenadePipebombProjectile))
+            return *stickies;
         if (CE_INT(ent, netvar.iPipeType) == 0)
-            return false;
+            return *pipes;
+    }
 
-    if (!flares && ent->m_iClassID() == CL_CLASS(CTFProjectile_Flare))
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Arrow))
+        return *arrows;
+
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Jar) || ent->m_iClassID() == CL_CLASS(CTFProjectile_JarMilk))
+        return *jars;
+
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_HealingBolt))
+        return *healingbolts;
+
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Rocket))
+        return *rockets;
+
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_SentryRocket))
+        return *sentryrockets;
+
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Cleaver))
+        return *cleavers;
+
+    if (ent->m_iClassID() == CL_CLASS(CTFGrapplingHook))
         return false;
 
-    if (!arrows && ent->m_iClassID() == CL_CLASS(CTFProjectile_Arrow))
-        return false;
-
-    if (!jars && (ent->m_iClassID() == CL_CLASS(CTFProjectile_Jar)) || ent->m_iClassID() == CL_CLASS(CTFProjectile_JarMilk))
-        return false;
-
-    if (!healingbolts && ent->m_iClassID() == CL_CLASS(CTFProjectile_HealingBolt))
-        return false;
-
-    if (!rockets &&  ent->m_iClassID() == CL_CLASS(CTFProjectile_Rocket))
-        return false;
-
-    if (!sentryrockets && ent->m_iClassID() == CL_CLASS(CTFProjectile_SentryRocket))
-        return false;
-
-    if (!cleavers && ent->m_iClassID() == CL_CLASS(CTFProjectile_Cleaver))
-        return false;
-
-    // Target passed the test, return true
-    return true;
+    // Target is not known, return default value
+    return *proj_default;
 }
 
 // Function called by game for movement
@@ -158,11 +155,11 @@ void CreateMove()
             }
         }
 
-         /*else {
-            // Stickys are weird, we use a different way to vis check them
-            // Vis checking stickys are wonky, I quit, just ignore the check >_>
-            //if (!VisCheckEntFromEnt(ent, LOCAL_E)) continue;
-        }*/
+        /*else {
+           // Stickys are weird, we use a different way to vis check them
+           // Vis checking stickys are wonky, I quit, just ignore the check >_>
+           //if (!VisCheckEntFromEnt(ent, LOCAL_E)) continue;
+       }*/
 
         // Calculate distance
         float dist = predicted_proj.DistToSqr(g_pLocalPlayer->v_Origin);

--- a/src/hacks/AutoReflect.cpp
+++ b/src/hacks/AutoReflect.cpp
@@ -119,7 +119,7 @@ bool IsEntSentryRocket(CachedEntity *ent)
 
 bool IsEntBall(CachedEntity *ent)
 {
-    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_BallOfFire) || ent->m_iClassID() == CL_CLASS(CTFProjectile_EnergyBall))
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_StunBall || CTFProjectile_BallOrnament))
         return true;
     else
         return false;
@@ -127,7 +127,7 @@ bool IsEntBall(CachedEntity *ent)
 
 bool IsEntCleaver(CachedEntity *ent)
 {
-    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_BallOfFire) || ent->m_iClassID() == CL_CLASS(CTFProjectile_Cleaver))
+    if (ent->m_iClassID() == CL_CLASS(ent->m_iClassID() == CL_CLASS(CTFProjectile_Cleaver))
         return true;
     else
         return false;

--- a/src/hacks/AutoReflect.cpp
+++ b/src/hacks/AutoReflect.cpp
@@ -16,16 +16,16 @@ static settings::Boolean legit{ "autoreflect.legit", "false" };
 static settings::Boolean dodgeball{ "autoreflect.dodgeball", "false" };
 static settings::Button blastkey{ "autoreflect.button", "<null>" };
 
-static settings::Boolean stickies{ "autoreflect.stickies", "false" };
-static settings::Boolean pipes{ "autoreflect.pipes", "false" };
+static settings::Boolean stickies{ "autoreflect.stickies", "true" };
+static settings::Boolean pipes{ "autoreflect.pipes", "true" };
 static settings::Boolean flares{ "autoreflect.flares", "false"};
 static settings::Boolean arrows{ "autoreflect.arrows", "false"};
 static settings::Boolean jars{ "autoreflect.jars", "false"};
 static settings::Boolean healingbolts{ "autoreflect.healingbolts", "false"};
-static settings::Boolean rockets{ "autoreflect.rockets", "false"};
-static settings::Boolean sentryrockets{ "autoreflect.sentryrockets", "false"};
+static settings::Boolean rockets{ "autoreflect.rockets", "true"};
+static settings::Boolean sentryrockets{ "autoreflect.sentryrockets", "true"};
 static settings::Boolean cleavers{ "autoreflect.cleavers", "false"};
-static settings::Boolean teammates{ "autoreflect.teammate", "false" };
+static settings::Boolean teammates{ "autoreflect.teammate", "true" };
 
 static settings::Float fov{ "autoreflect.fov", "85" };
 
@@ -35,97 +35,9 @@ static settings::Boolean fov_draw{ "autoreflect.draw-fov", "false" };
 static settings::Float fovcircle_opacity{ "autoreflect.draw-fov-opacity", "0.7" };
 #endif
 
-bool IsEntStickyBomb(CachedEntity *ent)
-{
-    // Check if the projectile is a sticky bomb
-    if (ent->m_iClassID() == CL_CLASS(CTFGrenadePipebombProjectile))
-    {
-        if (CE_INT(ent, netvar.iPipeType) == 1)
-        {
-            // Ent passed and should be reflected
-            return true;
-        }
-    }
-    // Ent didnt pass the test so return false
-    return false;
-}
-
-bool IsEntPipeBomb(CachedEntity *ent)
-{
-    // Check if the projectile is a sticky bomb
-    if (ent->m_iClassID() == CL_CLASS(CTFGrenadePipebombProjectile))
-    {
-        if (CE_INT(ent, netvar.iPipeType) == 0)
-        {
-            // Ent passed and should be reflected
-            return true;
-        }
-    }
-    // Ent didnt pass the test so return false
-    return false;
-}
-
-//Same as above but for other projectiles
-
-bool IsEntFlare(CachedEntity *ent)
-{
-    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Flare))
-        return true;
-    else
-        return false;
-}
-
-bool IsEntArrow(CachedEntity *ent)
-{
-    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Arrow))
-        return true;
-    else
-        return false;
-}
-
-bool IsEntJar(CachedEntity *ent)
-{
-    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Jar) || ent->m_iClassID() == CL_CLASS(CTFProjectile_JarMilk))
-        return true;
-    else
-        return false;
-}
-
-bool IsEntHealingBolt(CachedEntity *ent)
-{
-    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_HealingBolt))
-        return true;
-    else
-        return false;
-}
-
-
-bool IsEntRocket(CachedEntity *ent)
-{
-    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Rocket))
-        return true;
-    else
-        return false;
-}
-
-bool IsEntSentryRocket(CachedEntity *ent)
-{
-    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_SentryRocket))
-        return true;
-    else
-        return false;
-}
-
-bool IsEntCleaver(CachedEntity *ent)
-{
-    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Cleaver))
-        return true;
-    else
-        return false;
-}
 
 // Function to determine whether an ent is good to reflect
-bool ShouldReflect(CachedEntity *ent)
+static bool ShouldReflect(CachedEntity *ent)
 {
     // Check if the entity is a projectile
     if (ent->m_Type() != ENTITY_PROJECTILE)
@@ -149,36 +61,39 @@ bool ShouldReflect(CachedEntity *ent)
             return false;
     }
 
-    // Check if the projectile is a sticky bomb and if the user settings allow
-    // it to be reflected
 
 
-    if (IsEntStickyBomb(ent) && !stickies)
+    // Checks if the projectile is x and if the user settings allow it to be reflected
+    // If not, returns false
+
+    if (!stickies && ent->m_iClassID() == CL_CLASS(CTFGrenadePipebombProjectile))
+        //Checks the demoguy projectile type (both stickies and pipes are combined under PipeBombProjectile)
+        if (CE_INT(ent, netvar.iPipeType) == 1)
+            return false;
+
+    if (!pipes && ent->m_iClassID() == CL_CLASS(CTFGrenadePipebombProjectile))
+        if (CE_INT(ent, netvar.iPipeType) == 0)
+            return false;
+
+    if (!flares && ent->m_iClassID() == CL_CLASS(CTFProjectile_Flare))
         return false;
 
-    //Same as above but for other projectile types
-    else if (IsEntPipeBomb(ent) && !pipes)
+    if (!arrows && ent->m_iClassID() == CL_CLASS(CTFProjectile_Arrow))
         return false;
 
-    else if (IsEntFlare(ent) && !flares)
+    if (!jars && (ent->m_iClassID() == CL_CLASS(CTFProjectile_Jar)) || ent->m_iClassID() == CL_CLASS(CTFProjectile_JarMilk))
         return false;
 
-    else if (IsEntArrow(ent) && !arrows)
+    if (!healingbolts && ent->m_iClassID() == CL_CLASS(CTFProjectile_HealingBolt))
         return false;
 
-    else if (IsEntJar(ent) && !jars)
+    if (!rockets &&  ent->m_iClassID() == CL_CLASS(CTFProjectile_Rocket))
         return false;
 
-    else if (IsEntHealingBolt(ent) && !healingbolts)
+    if (!sentryrockets && ent->m_iClassID() == CL_CLASS(CTFProjectile_SentryRocket))
         return false;
 
-    else if (IsEntRocket(ent) && !rockets)
-        return false;
-
-    else if (IsEntSentryRocket(ent) && !sentryrockets)
-        return false;
-
-    else if (IsEntCleaver(ent) && !cleavers)
+    if (!cleavers && ent->m_iClassID() == CL_CLASS(CTFProjectile_Cleaver))
         return false;
 
     // Target passed the test, return true
@@ -233,11 +148,14 @@ void CreateMove()
         Vector predicted_proj = ent->m_vecOrigin() + (velocity * latency);
 
         // Dont vischeck if ent is stickybomb or if dodgeball mode is enabled
-        if (!IsEntStickyBomb(ent) && !dodgeball)
+        if (ent->m_iClassID() == CL_CLASS(CTFGrenadePipebombProjectile) && !dodgeball)
         {
-            // Vis check the predicted vector
-            if (!IsVectorVisible(g_pLocalPlayer->v_Origin, predicted_proj))
-                continue;
+            if (CE_INT(ent, netvar.iPipeType) == 1)
+            {
+                // Vis check the predicted vector
+                if (!IsVectorVisible(g_pLocalPlayer->v_Origin, predicted_proj))
+                    continue;
+            }
         }
 
          /*else {

--- a/src/hacks/AutoReflect.cpp
+++ b/src/hacks/AutoReflect.cpp
@@ -118,7 +118,7 @@ bool IsEntSentryRocket(CachedEntity *ent)
 
 bool IsEntCleaver(CachedEntity *ent)
 {
-    if (ent->m_iClassID() == CL_CLASS(ent->m_iClassID() == CL_CLASS(CTFProjectile_Cleaver))
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Cleaver))
         return true;
     else
         return false;
@@ -178,7 +178,7 @@ bool ShouldReflect(CachedEntity *ent)
     else if (IsEntSentryRocket(ent) && !sentryrockets)
         return false;
 
-    else if (IsEntCleaver(ent) && !balls)
+    else if (IsEntCleaver(ent) && !cleavers)
         return false;
 
     // Target passed the test, return true

--- a/src/hacks/AutoReflect.cpp
+++ b/src/hacks/AutoReflect.cpp
@@ -24,6 +24,7 @@ static settings::Boolean jars{ "autoreflect.jars", "false"};
 static settings::Boolean healingbolts{ "autoreflect.healingbolts", "false"};
 static settings::Boolean rockets{ "autoreflect.rockets", "false"};
 static settings::Boolean sentryrockets{ "autoreflect.sentryrockets", "false"};
+static settings::Boolean balls{ "autoreflect.balls", "false"};
 static settings::Boolean cleavers{ "autoreflect.cleavers", "false"};
 static settings::Boolean teammates{ "autoreflect.teammate", "false" };
 
@@ -116,6 +117,14 @@ bool IsEntSentryRocket(CachedEntity *ent)
         return false;
 }
 
+bool IsEntBall(CachedEntity *ent)
+{
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_StunBall || CTFProjectile_BallOrnament))
+        return true;
+    else
+        return false;
+}
+
 bool IsEntCleaver(CachedEntity *ent)
 {
     if (ent->m_iClassID() == CL_CLASS(ent->m_iClassID() == CL_CLASS(CTFProjectile_Cleaver))
@@ -176,6 +185,9 @@ bool ShouldReflect(CachedEntity *ent)
         return false;
 
     else if (IsEntSentryRocket(ent) && !sentryrockets)
+        return false;
+
+    else if (IsEntBall(ent) && !balls)
         return false;
 
     else if (IsEntCleaver(ent) && !balls)

--- a/src/hacks/AutoReflect.cpp
+++ b/src/hacks/AutoReflect.cpp
@@ -24,7 +24,6 @@ static settings::Boolean jars{ "autoreflect.jars", "false"};
 static settings::Boolean healingbolts{ "autoreflect.healingbolts", "false"};
 static settings::Boolean rockets{ "autoreflect.rockets", "false"};
 static settings::Boolean sentryrockets{ "autoreflect.sentryrockets", "false"};
-static settings::Boolean balls{ "autoreflect.balls", "false"};
 static settings::Boolean cleavers{ "autoreflect.cleavers", "false"};
 static settings::Boolean teammates{ "autoreflect.teammate", "false" };
 
@@ -117,14 +116,6 @@ bool IsEntSentryRocket(CachedEntity *ent)
         return false;
 }
 
-bool IsEntBall(CachedEntity *ent)
-{
-    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_StunBall || CTFProjectile_BallOrnament))
-        return true;
-    else
-        return false;
-}
-
 bool IsEntCleaver(CachedEntity *ent)
 {
     if (ent->m_iClassID() == CL_CLASS(ent->m_iClassID() == CL_CLASS(CTFProjectile_Cleaver))
@@ -185,9 +176,6 @@ bool ShouldReflect(CachedEntity *ent)
         return false;
 
     else if (IsEntSentryRocket(ent) && !sentryrockets)
-        return false;
-
-    else if (IsEntBall(ent) && !balls)
         return false;
 
     else if (IsEntCleaver(ent) && !balls)

--- a/src/hacks/AutoReflect.cpp
+++ b/src/hacks/AutoReflect.cpp
@@ -15,9 +15,21 @@ static settings::Boolean idle_only{ "autoreflect.idle-only", "false" };
 static settings::Boolean legit{ "autoreflect.legit", "false" };
 static settings::Boolean dodgeball{ "autoreflect.dodgeball", "false" };
 static settings::Button blastkey{ "autoreflect.button", "<null>" };
+
 static settings::Boolean stickies{ "autoreflect.stickies", "false" };
+static settings::Boolean pipes{ "autoreflect.pipes", "false" };
+static settings::Boolean flares{ "autoreflect.flares", "false"};
+static settings::Boolean arrows{ "autoreflect.arrows", "false"};
+static settings::Boolean jars{ "autoreflect.jars", "false"};
+static settings::Boolean healingbolts{ "autoreflect.healingbolts", "false"};
+static settings::Boolean rockets{ "autoreflect.rockets", "false"};
+static settings::Boolean sentryrockets{ "autoreflect.sentryrockets", "false"};
+static settings::Boolean balls{ "autoreflect.balls", "false"};
+static settings::Boolean cleavers{ "autoreflect.cleavers", "false"};
 static settings::Boolean teammates{ "autoreflect.teammate", "false" };
+
 static settings::Float fov{ "autoreflect.fov", "85" };
+
 
 #if ENABLE_VISUALS
 static settings::Boolean fov_draw{ "autoreflect.draw-fov", "false" };
@@ -37,6 +49,88 @@ bool IsEntStickyBomb(CachedEntity *ent)
     }
     // Ent didnt pass the test so return false
     return false;
+}
+
+bool IsEntPipeBomb(CachedEntity *ent)
+{
+    // Check if the projectile is a sticky bomb
+    if (ent->m_iClassID() == CL_CLASS(CTFGrenadePipebombProjectile))
+    {
+        if (CE_INT(ent, netvar.iPipeType) == 0)
+        {
+            // Ent passed and should be reflected
+            return true;
+        }
+    }
+    // Ent didnt pass the test so return false
+    return false;
+}
+
+//Same as above but for other projectiles
+
+bool IsEntFlare(CachedEntity *ent)
+{
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Flare))
+        return true;
+    else
+        return false;
+}
+
+bool IsEntArrow(CachedEntity *ent)
+{
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Arrow))
+        return true;
+    else
+        return false;
+}
+
+bool IsEntJar(CachedEntity *ent)
+{
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Jar) || ent->m_iClassID() == CL_CLASS(CTFProjectile_JarMilk))
+        return true;
+    else
+        return false;
+}
+
+bool IsEntHealingBolt(CachedEntity *ent)
+{
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_HealingBolt))
+        return true;
+    else
+        return false;
+}
+
+
+bool IsEntRocket(CachedEntity *ent)
+{
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_Rocket))
+        return true;
+    else
+        return false;
+}
+
+bool IsEntSentryRocket(CachedEntity *ent)
+{
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_SentryRocket))
+        return true;
+    else
+        return false;
+}
+
+bool IsEntBall(CachedEntity *ent)
+{
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_BallOfFire) || ent->m_iClassID() == CL_CLASS(CTFProjectile_EnergyBall))
+        return true;
+    else
+        return false;
+}
+
+bool IsEntCleaver(CachedEntity *ent)
+{
+    if (ent->m_iClassID() == CL_CLASS(CTFProjectile_BallOfFire) || ent->m_iClassID() == CL_CLASS(CTFProjectile_Cleaver))
+        return true;
+    else
+        return false;
 }
 
 // Function to determine whether an ent is good to reflect
@@ -66,7 +160,37 @@ bool ShouldReflect(CachedEntity *ent)
 
     // Check if the projectile is a sticky bomb and if the user settings allow
     // it to be reflected
+
+
     if (IsEntStickyBomb(ent) && !stickies)
+        return false;
+
+    //Same as above but for other projectile types
+    else if (IsEntPipeBomb(ent) && !pipes)
+        return false;
+
+    else if (IsEntFlare(ent) && !flares)
+        return false;
+
+    else if (IsEntArrow(ent) && !arrows)
+        return false;
+
+    else if (IsEntJar(ent) && !jars)
+        return false;
+
+    else if (IsEntHealingBolt(ent) && !healingbolts)
+        return false;
+
+    else if (IsEntRocket(ent) && !rockets)
+        return false;
+
+    else if (IsEntSentryRocket(ent) && !sentryrockets)
+        return false;
+
+    else if (IsEntBall(ent) && !balls)
+        return false;
+
+    else if (IsEntCleaver(ent) && !balls)
         return false;
 
     // Target passed the test, return true
@@ -126,7 +250,9 @@ void CreateMove()
             // Vis check the predicted vector
             if (!IsVectorVisible(g_pLocalPlayer->v_Origin, predicted_proj))
                 continue;
-        } /*else {
+        }
+
+         /*else {
             // Stickys are weird, we use a different way to vis check them
             // Vis checking stickys are wonky, I quit, just ignore the check >_>
             //if (!VisCheckEntFromEnt(ent, LOCAL_E)) continue;


### PR DESCRIPTION
Mostly just modified IsEntStickyBomb and places where it's referenced to fit other projectiles. Feel like a lot of this could probably be made way more efficient, but it works I suppose

Created in response to #862 