### PR TITLE
Bhop chance and maximize sticky damage

### DIFF
--- a/data/menu/nullifiedcat/movement.xml
+++ b/data/menu/nullifiedcat/movement.xml
@@ -2,6 +2,7 @@
     <Box padding="12 6 6 6" width="content" height="content" name="Bunny Hop">
         <List width="150">
             <AutoVariable width="fill" target="bunnyhop.enable" label="Enable Bunny Hop"/>
+	    <AutoVariable width="fill" target="bunnyhop.chance" label="Bhop Chance"/>
             <AutoVariable width="fill" target="misc.autostrafe" label="Enable Auto strafe"/>
         </List>
     </Box>
@@ -27,7 +28,7 @@
             <AutoVariable width="fill" target="follow-bot.draw-crumbs" label="Draw Crumbs"/>
         </List>
     </Box>
-    <Box padding="12 6 6 6" width="content" height="content" name="NavBot" y="50">
+    <Box padding="12 6 6 6" width="content" height="content" name="NavBot" y="65">
         <List width="150">
             <AutoVariable width="fill" target="misc.pathing" label="Enable Pathing"/>
 	        <AutoVariable width="fill" target="misc.pathing.draw" label="Draw Path"/>

--- a/data/menu/nullifiedcat/trigger/autosticky.xml
+++ b/data/menu/nullifiedcat/trigger/autosticky.xml
@@ -5,7 +5,7 @@
             <AutoVariable width="fill" target="autosticky.buildings" label="Detonate On Buildings"/>
             <AutoVariable width="fill" target="autosticky.legit" label="Legit Mode"/>
             <AutoVariable width="fill" target="autosticky.dontblowmeup" label="Don't Blow Me Up"/>
-            <AutoVariable width="fill" target="autosticky.damage" label="Maximize Damage"/>
+            <AutoVariable width="fill" target="autosticky.min-dist" label="Min Distance" min="0" max="130" step="5"/>
         </List>
     </Box>
 </Tab>

--- a/data/menu/nullifiedcat/trigger/autosticky.xml
+++ b/data/menu/nullifiedcat/trigger/autosticky.xml
@@ -5,6 +5,7 @@
             <AutoVariable width="fill" target="autosticky.buildings" label="Detonate On Buildings"/>
             <AutoVariable width="fill" target="autosticky.legit" label="Legit Mode"/>
             <AutoVariable width="fill" target="autosticky.dontblowmeup" label="Don't Blow Me Up"/>
+            <AutoVariable width="fill" target="autosticky.damage" label="Maximize Damage"/>
         </List>
     </Box>
 </Tab>

--- a/src/hacks/AutoSticky.cpp
+++ b/src/hacks/AutoSticky.cpp
@@ -16,7 +16,7 @@ static settings::Boolean enable{ "autosticky.enable", "false" };
 static settings::Boolean buildings{ "autosticky.buildings", "true" };
 static settings::Boolean legit{ "autosticky.legit", "false" };
 static settings::Boolean dontblowmeup{ "autosticky.dontblowmeup", "true" };
-static settings::Boolean maximize_damage{ "autosticky.damage", "false" };
+static settings::Int min_dist{ "autosticky.min-dist", "130" };
 
 // A storage array for ents
 static std::vector<CachedEntity *> bombs;
@@ -160,14 +160,8 @@ void CreateMove()
 
             position = *position + (collideable->OBBMins() + collideable->OBBMaxs()) / 2;
 
-            int min_dist;
-            if (maximize_damage)
-                min_dist = 80;
-            else
-                min_dist = 130;
-            
             if (!found)
-                if (bomb->m_vecOrigin().DistTo(*position) < min_dist)
+                if (bomb->m_vecOrigin().DistTo(*position) < *min_dist)
                 {
                     // Vis check the target from the bomb
                     if (IsVectorVisible(bomb->m_vecOrigin(), *position, true))

--- a/src/hacks/AutoSticky.cpp
+++ b/src/hacks/AutoSticky.cpp
@@ -16,6 +16,7 @@ static settings::Boolean enable{ "autosticky.enable", "false" };
 static settings::Boolean buildings{ "autosticky.buildings", "true" };
 static settings::Boolean legit{ "autosticky.legit", "false" };
 static settings::Boolean dontblowmeup{ "autosticky.dontblowmeup", "true" };
+static settings::Boolean maximize_damage{ "autosticky.damage", "false" };
 
 // A storage array for ents
 static std::vector<CachedEntity *> bombs;
@@ -159,8 +160,14 @@ void CreateMove()
 
             position = *position + (collideable->OBBMins() + collideable->OBBMaxs()) / 2;
 
+            int min_dist;
+            if (maximize_damage)
+                min_dist = 70;
+            else
+                min_dist = 130;
+            
             if (!found)
-                if (bomb->m_vecOrigin().DistTo(*position) < 130)
+                if (bomb->m_vecOrigin().DistTo(*position) < min_dist)
                 {
                     // Vis check the target from the bomb
                     if (IsVectorVisible(bomb->m_vecOrigin(), *position, true))

--- a/src/hacks/AutoSticky.cpp
+++ b/src/hacks/AutoSticky.cpp
@@ -162,7 +162,7 @@ void CreateMove()
 
             int min_dist;
             if (maximize_damage)
-                min_dist = 70;
+                min_dist = 80;
             else
                 min_dist = 130;
             

--- a/src/hacks/Bunnyhop.cpp
+++ b/src/hacks/Bunnyhop.cpp
@@ -11,6 +11,7 @@
 namespace hacks::shared::bunnyhop
 {
 static settings::Boolean enable{ "bunnyhop.enable", "false" };
+static settings::Int bhop_chance{ "bunnyhop.chance", "100" };
 
 // Var for user settings
 
@@ -30,6 +31,10 @@ static void CreateMove()
     if (!current_user_cmd->command_number)
         return;
 
+    // Bhop likelihood
+    if (UniformRandomInt(0, 99) > *bhop_chance)
+        return;
+    
     // var for "if on ground" from the flags netvar
     bool ground = CE_INT(g_pLocalPlayer->entity, netvar.iFlags) & (1 << 0);
     // Var for if the player is pressing jump


### PR DESCRIPTION
Two features that I thought were missing are a chance option to bhopping and a maximize sticky damage option. Bhop chance is the percent likelihood that a bhop succeeds. By default, auto sticky makes stickies blow up when someone is 130 hammer units away, which limited their damage in my play testing. This new option reduces the trigger radius to 80 hammer units, so they do more damage.