### PR TITLE
Fix KillfeedColor not compiling with Stream safety

### DIFF
--- a/src/hacks/KillfeedColor.cpp
+++ b/src/hacks/KillfeedColor.cpp
@@ -172,6 +172,5 @@ mov [esp], ecx
         }
     });
 });
-
-#endif
 }
+#endif


### PR DESCRIPTION
How did we not see this?