### PR TITLE
Fixed Bone ESP and More

### DIFF
--- a/data/menu/nullifiedcat/aimbot.xml
+++ b/data/menu/nullifiedcat/aimbot.xml
@@ -83,6 +83,7 @@
             </LabeledObject>
             <AutoVariable width="fill" target="aimbot.target.max-range" label="Max Range"/>
             <AutoVariable width="fill" target="aimbot.multipoint" label="Multipoint"/>
+            <AutoVariable width="fill" target="aimbot.assistance.only" label="Assistance Only" tooltip="Aimbot is only active if your mouse has moved in the last half second."/>
             <AutoVariable width="fill" target="aimbot.lock-target" label="Lock Target" tooltip="Lock onto a target until they die or leave your fov."/>
             <AutoVariable width="fill" target="aimbot.target.ignore-non-rage" label="Rage Only"/>
             <AutoVariable width="fill" target="aimbot.target.stickybomb" label="Aim at Stickybombs"/>
@@ -123,7 +124,7 @@
             </LabeledObject>
         </List>
     </Box>
-    <Box padding="12 6 6 6" width="content" height="content" name="Sandvich Aimbot" x="170" y="240">
+    <Box padding="12 6 6 6" width="content" height="content" name="Sandvich Aimbot" x="170" y="255">
         <List width="150">
             <AutoVariable width="fill" target="sandwichaim.enable" label="Enable Sandvich Aimbot"/>
             <AutoVariable width="fill" target="sandwichaim.aimkey" label="Aimkey"/>

--- a/data/menu/nullifiedcat/visuals/esp.xml
+++ b/data/menu/nullifiedcat/visuals/esp.xml
@@ -65,6 +65,7 @@
             <AutoVariable width="fill" target="esp.box.building-3d" label="3D Buildings"/>
             <AutoVariable width="fill" target="esp.box.corner-size" label="Corner Size"/>
             <AutoVariable width="fill" target="esp.bones" label="Bone ESP"/>
+            <AutoVariable width="fill" target="esp.bones.color" label="Bone Color"/>
             <AutoVariable width="fill" target="esp.sightlines" label="Sightlines"/>
             <AutoVariable width="fill" target="esp.expand" label="Expand"/>
             <LabeledObject width="fill" label="Text Position">

--- a/data/menu/nullifiedcat/visuals/radar.xml
+++ b/data/menu/nullifiedcat/visuals/radar.xml
@@ -25,6 +25,7 @@
             <AutoVariable width="fill" target="radar.show.ammo" label="Ammo Packs"/>
             <AutoVariable width="fill" target="radar.show.health" label="Health Packs"/>
             <AutoVariable width="fill" target="radar.show.teammates" label="Teammates"/>
+	    <AutoVariable width="fill" target="radar.show.team.buildings" label="Team Buildings"/>
         </List>
     </Box>
 </Tab>

--- a/src/hacks/ESP.cpp
+++ b/src/hacks/ESP.cpp
@@ -171,9 +171,9 @@ struct bonelist_s
         }
     }
 
-    void _FASTCALL Draw(CachedEntity *enti, const rgba_t &color)
+    void _FASTCALL Draw(CachedEntity *ent, const rgba_t &color)
     {
-        const model_t *model = RAW_ENT(enti)->GetModel();
+        const model_t *model = RAW_ENT(ent)->GetModel();
         if (not model)
         {
             return;
@@ -189,7 +189,7 @@ struct bonelist_s
             return;
 
         // ent->m_bBonesSetup = false;
-        const auto &bones   = enti->hitboxes.GetBones();
+        const auto &bones   = ent->hitboxes.GetBones();
         DrawBoneList(bones, leg_r, 3, color);
         DrawBoneList(bones, leg_l, 3, color);
         DrawBoneList(bones, bottom, 3, color);

--- a/src/hacks/ESP.cpp
+++ b/src/hacks/ESP.cpp
@@ -30,6 +30,7 @@ static settings::Int emoji_min_size{ "esp.emoji.min-size", "20" };
 
 static settings::Int healthbar{ "esp.health-bar", "3" };
 static settings::Boolean draw_bones{ "esp.bones", "false" };
+static settings::Boolean bones_color{ "esp.bones.color", "false" };
 static settings::Int sightlines{ "esp.sightlines", "0" };
 static settings::Int esp_text_position{ "esp.text-position", "0" };
 static settings::Int esp_expand{ "esp.expand", "0" };
@@ -150,7 +151,7 @@ struct bonelist_s
         setup = true;
     }
 
-    void DrawBoneList(const matrix3x4_t *bones, int *in, int size, const rgba_t &color, const Vector &displacement)
+    void _FASTCALL DrawBoneList(const matrix3x4_t *bones, int *in, int size, const rgba_t &color)
     {
         Vector last_screen;
         Vector current_screen;
@@ -158,7 +159,6 @@ struct bonelist_s
         {
             const auto &bone = bones[in[i]];
             Vector position(bone[0][3], bone[1][3], bone[2][3]);
-            position += displacement;
             if (!draw::WorldToScreen(position, current_screen))
             {
                 return;
@@ -171,9 +171,9 @@ struct bonelist_s
         }
     }
 
-    void Draw(CachedEntity *ent, const rgba_t &color)
+    void _FASTCALL Draw(CachedEntity *enti, const rgba_t &color)
     {
-        const model_t *model = RAW_ENT(ent)->GetModel();
+        const model_t *model = RAW_ENT(enti)->GetModel();
         if (not model)
         {
             return;
@@ -189,15 +189,14 @@ struct bonelist_s
             return;
 
         // ent->m_bBonesSetup = false;
-        Vector displacement = {};
-        const auto &bones   = ent->hitboxes.GetBones();
-        DrawBoneList(bones, leg_r, 3, color, displacement);
-        DrawBoneList(bones, leg_l, 3, color, displacement);
-        DrawBoneList(bones, bottom, 3, color, displacement);
-        DrawBoneList(bones, spine, 7, color, displacement);
-        DrawBoneList(bones, arm_r, 3, color, displacement);
-        DrawBoneList(bones, arm_l, 3, color, displacement);
-        DrawBoneList(bones, up, 3, color, displacement);
+        const auto &bones   = enti->hitboxes.GetBones();
+        DrawBoneList(bones, leg_r, 3, color);
+        DrawBoneList(bones, leg_l, 3, color);
+        DrawBoneList(bones, bottom, 3, color);
+        DrawBoneList(bones, spine, 7, color);
+        DrawBoneList(bones, arm_r, 3, color);
+        DrawBoneList(bones, arm_l, 3, color);
+        DrawBoneList(bones, up, 3, color);
         /*for (int i = 0; i < hdr->numbones; i++) {
             const auto& bone = ent->GetBones()[i];
             Vector pos(bone[0][3], bone[1][3], bone[2][3]);
@@ -625,6 +624,24 @@ void _FASTCALL ProcessEntityPT(CachedEntity *ent)
             break;
         }
     }
+
+	if (draw_bones)
+	{
+        if (vischeck && !ent->IsVisible())
+            transparent = true;
+		rgba_t bone_color = colors::EntityF(ent);
+        if (transparent)
+            bone_color = colors::Transparent(bone_color);
+
+		bonelist_s bl;
+		if (!CE_INVALID(ent) && ent->m_bAlivePlayer() && !RAW_ENT(ent)->IsDormant() && LOCAL_E->m_bAlivePlayer())
+		{
+			if (bones_color)
+				bl.Draw(ent, bone_color);
+			else
+				bl.Draw(ent, colors::white);
+		}
+	}
 
     // Top horizontal health bar
     if (*healthbar == 1)

--- a/src/hacks/Radar.cpp
+++ b/src/hacks/Radar.cpp
@@ -24,7 +24,9 @@ static settings::Int icon_size{ "radar.icon-size", "20" };
 static settings::Int radar_x{ "radar.x", "100" };
 static settings::Int radar_y{ "radar.y", "100" };
 static settings::Boolean use_icons{ "radar.use-icons", "true" };
+static settings::Boolean show_self{ "radar.show.self", "true" };
 static settings::Boolean show_teammates{ "radar.show.teammates", "true" };
+static settings::Boolean show_teambuildings{ "radar.show.team.buildings", "true" };
 static settings::Boolean show_healthpacks{ "radar.show.health", "true" };
 static settings::Boolean show_ammopacks{ "radar.show.ammo", "true" };
 
@@ -247,6 +249,10 @@ void Draw()
         if (i == g_IEngine->GetLocalPlayer())
             continue;
         if (!show_teammates && ent->m_Type() == ENTITY_PLAYER && !ent->m_bEnemy())
+            continue;
+        if (!show_teambuildings && ent->m_Type() == ENTITY_BUILDING && !ent->m_bEnemy())
+            continue;
+        if (!show_self && ent->m_IDX == LOCAL_E->m_IDX)
             continue;
         if (ent->m_iClassID() == CL_CLASS(CObjectSentrygun))
             sentries.push_back(ent);

--- a/src/hacks/Radar.cpp
+++ b/src/hacks/Radar.cpp
@@ -24,7 +24,6 @@ static settings::Int icon_size{ "radar.icon-size", "20" };
 static settings::Int radar_x{ "radar.x", "100" };
 static settings::Int radar_y{ "radar.y", "100" };
 static settings::Boolean use_icons{ "radar.use-icons", "true" };
-static settings::Boolean show_self{ "radar.show.self", "true" };
 static settings::Boolean show_teammates{ "radar.show.teammates", "true" };
 static settings::Boolean show_teambuildings{ "radar.show.team.buildings", "true" };
 static settings::Boolean show_healthpacks{ "radar.show.health", "true" };
@@ -251,8 +250,6 @@ void Draw()
         if (!show_teammates && ent->m_Type() == ENTITY_PLAYER && !ent->m_bEnemy())
             continue;
         if (!show_teambuildings && ent->m_Type() == ENTITY_BUILDING && !ent->m_bEnemy())
-            continue;
-        if (!show_self && ent->m_IDX == LOCAL_E->m_IDX)
             continue;
         if (ent->m_iClassID() == CL_CLASS(CObjectSentrygun))
             sentries.push_back(ent);


### PR DESCRIPTION
This Pull Request:
-fixes bone ESP and adds an option to color it according to player state
-adds an "assist only" option to aimbot that makes it only active if the mouse has moved in the last half second. This is useful for playing legit.
-adds a radar option for team buildings

Also, the bytepatch for keeping the sniper rifle breaks the command `zoom_sensitivity_ratio`