### PR TITLE
very small edit to bruteforce angles

### DIFF
--- a/src/hacks/AntiAntiAim.cpp
+++ b/src/hacks/AntiAntiAim.cpp
@@ -39,7 +39,7 @@ void frameStageNotify(ClientFrameStage_t stage)
 #endif
 }
 
-static std::array<float, 5> yaw_resolves{ 0.0f, 180.0f, 90.0f, -90.0f, -180.0f };
+static std::array<float, 5> yaw_resolves{ 0.0f, 180.0f, 65.0f, -65.0f, -180.0f };
 
 static float resolveAngleYaw(float angle, brutedata &brute)
 {


### PR DESCRIPTION
abuses the ~20deg area of hitbox that the head can be in while bruteforcing, to cover wider ranges than +90/-90