### PR TITLE
Add ubuntu 20.04 support

### DIFF
--- a/scripts/dependencycheck
+++ b/scripts/dependencycheck
@@ -6,7 +6,7 @@ GIT=${1:-false}
 SUDO=${CH_SUDO:-sudo}
 
 arch_packages=(git boost cmake make gcc gdb lib32-sdl2 lib32-glew lib32-freetype2 rsync lib32-libglvnd dialog)
-ubuntu_packages=(software-properties-common build-essential git g++ g++-multilib libboost-dev gdb libsdl2-dev:i386 libglew-dev:i386 libfreetype6-dev:i386 cmake dialog rsync)
+ubuntu_packages=(build-essential git g++ g++-multilib libboost-dev gdb libsdl2-dev:i386 libfreetype6-dev:i386 cmake dialog rsync)
 fedora_packages=(cmake dialog make gcc-c++ glibc-devel.i686 freetype-devel.i686 SDL2-devel.i686 glew-devel.i686 boost-devel rsync gdb git)
 
 # Check if we should only install git
@@ -71,12 +71,12 @@ elif [ "$OS" == "ubuntu" ]; then
     if [ "$out" == 1 ]; then
         requestPermissions "${ubuntu_packages[@]}"
         pkgs="${ubuntu_packages[@]}"
-        $SUDO bash -c "apt-get update;apt-get install -y software-properties-common;add-apt-repository ppa:ubuntu-toolchain-r/test -y;dpkg --add-architecture i386;apt-get update;apt-get install -y $pkgs"
+        $SUDO bash -c "apt-get update;dpkg --add-architecture i386;apt-get update;apt-get install -y $pkgs"
         # Check if cmake is up to date enough
         dpkg --compare-versions "$(dpkg-query --show --showformat '${Version}' cmake)" ge 3.12
         out=$?
         if [ "$out" == 1 ]; then
-            $SUDO bash -c "wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -; apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ bionic main'; apt-get install -y cmake"
+            $SUDO bash -c "apt install -y software-properties-common && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - && apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ bionic main' && apt-get install -y cmake"
         fi
     fi
 elif [ "$OS" == "fedora" ]; then

--- a/src/visual/drawing.cpp
+++ b/src/visual/drawing.cpp
@@ -20,7 +20,6 @@
 #include "picopng.hpp"
 #endif
 #include "menu/GuiInterface.hpp"
-#include <GL/glew.h>
 #include <SDL2/SDL_video.h>
 #include <SDLHooks.hpp>
 #include "soundcache.hpp"

--- a/src/visual/fidgetspinner.cpp
+++ b/src/visual/fidgetspinner.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "common.hpp"
-#include "../../external/libglez/ftgl/freetype-gl.h"
 
 #include <math.h>
 #include <settings/Bool.hpp>


### PR DESCRIPTION
Ubuntu 20.04 also inevitably has no support for libglez. Tested on Kubuntu 20.04 and on the Ubuntu 18.04 docker container.