### PR TITLE
Abandon logic improvements

### DIFF
--- a/include/core/offsets.hpp
+++ b/include/core/offsets.hpp
@@ -204,6 +204,10 @@ struct offsets
     {
         return PlatformOffset(128, undefined, undefined);
     }
+    static constexpr uint32_t ClientCmd_Unrestricted()
+    {
+        return PlatformOffset(106, undefined, undefined);
+    }
     static constexpr uint32_t EmitSound1()
     {
         return PlatformOffset(4, undefined, undefined);

--- a/include/hacks/CatBot.hpp
+++ b/include/hacks/CatBot.hpp
@@ -18,6 +18,7 @@ void init();
 void level_init();
 extern settings::Boolean catbotmode;
 extern settings::Boolean anti_motd;
+extern settings::Int abandon_if_ipc_bots_gte;
 
 #if ENABLE_IPC
 void update_ipc_data(ipc::user_data_s &data);

--- a/include/hooks.hpp
+++ b/include/hooks.hpp
@@ -76,4 +76,5 @@ extern VMTHook materialsystem;
 extern VMTHook enginevgui;
 extern VMTHook vstd;
 extern VMTHook eventmanager2;
+extern VMTHook cmdclientunrestricted;
 } // namespace hooks

--- a/include/hooks/HookedMethods.hpp
+++ b/include/hooks/HookedMethods.hpp
@@ -62,6 +62,7 @@ DECLARE_HOOKED_METHOD(FireEventClientSide, bool, IGameEventManager2 *, IGameEven
 // g_IEngine
 DECLARE_HOOKED_METHOD(IsPlayingTimeDemo, bool, void *);
 DECLARE_HOOKED_METHOD(ServerCmdKeyValues, void, IVEngineClient013 *, KeyValues *);
+DECLARE_HOOKED_METHOD(ClientCmd_Unrestricted, void, IVEngineClient013*, const char*);
 #if ENABLE_VISUALS || ENABLE_TEXTMODE
 // vgui::IPanel
 DECLARE_HOOKED_METHOD(PaintTraverse, void, vgui::IPanel *, unsigned int, bool, bool);

--- a/src/hack.cpp
+++ b/src/hack.cpp
@@ -230,6 +230,10 @@ void hack::Hook()
     hooks::engine.HookMethod(HOOK_ARGS(ServerCmdKeyValues));
     hooks::engine.Apply();
 
+    hooks::cmdclientunrestricted.Set(g_IEngine);
+    hooks::cmdclientunrestricted.HookMethod(HOOK_ARGS(ClientCmd_Unrestricted));
+    hooks::cmdclientunrestricted.Apply();
+
     hooks::demoplayer.Set(demoplayer);
     hooks::demoplayer.HookMethod(HOOK_ARGS(IsPlayingTimeDemo));
     hooks::demoplayer.Apply();

--- a/src/hacks/CatBot.cpp
+++ b/src/hacks/CatBot.cpp
@@ -20,7 +20,7 @@ namespace hacks::shared::catbot
 {
 static settings::Boolean auto_disguise{ "misc.autodisguise", "true" };
 
-static settings::Int abandon_if_ipc_bots_gte{ "cat-bot.abandon-if.ipc-bots-gte", "0" };
+settings::Int abandon_if_ipc_bots_gte{ "cat-bot.abandon-if.ipc-bots-gte", "0" };
 static settings::Int abandon_if_humans_lte{ "cat-bot.abandon-if.humans-lte", "0" };
 static settings::Int abandon_if_players_lte{ "cat-bot.abandon-if.players-lte", "0" };
 

--- a/src/hacks/CatBot.cpp
+++ b/src/hacks/CatBot.cpp
@@ -788,8 +788,11 @@ void update()
         ipc_list.clear();
         int count_total = 0;
 
-        for (int i = 1; i <= g_IEngine->GetMaxClients(); ++i)
+        for (int i = 0; i <= g_IEngine->GetMaxClients(); ++i)
         {
+            if (g_IEngine->GetLocalPlayer() == i)
+                continue;
+
             if (g_IEntityList->GetClientEntity(i))
                 ++count_total;
             else

--- a/src/hooks.cpp
+++ b/src/hooks.cpp
@@ -119,4 +119,5 @@ VMTHook soundclient{};
 VMTHook enginevgui{};
 VMTHook vstd{};
 VMTHook eventmanager2{};
+VMTHook cmdclientunrestricted{};
 } // namespace hooks

--- a/src/hooks/CMakeLists.txt
+++ b/src/hooks/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(files "${CMAKE_CURRENT_LIST_DIR}/CanPacket.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/ClientCmd_Unrestricted.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/CreateMove.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/DispatchUserMessage.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/EmitSound.cpp"

--- a/src/hooks/ClientCmd_Unrestricted.cpp
+++ b/src/hooks/ClientCmd_Unrestricted.cpp
@@ -8,10 +8,10 @@ namespace hooked_methods
 
 DEFINE_HOOKED_METHOD(ClientCmd_Unrestricted, void, IVEngineClient013* _this, const char* command)
 {
-    if (hacks::shared::catbot::abandon_if_ipc_bots_gte) {
+    if (ipc::peer && hacks::shared::catbot::abandon_if_ipc_bots_gte) {
         std::string command_str(command);
         
-        if (ipc::peer && command_str.length() >= 20 && command_str.substr(0, 7) == "connect") {
+        if (command_str.length() >= 20 && command_str.substr(0, 7) == "connect") {
             unsigned count_ipc = 0;
 
             if (command_str.substr(command_str.length() - 11, 11) == "matchmaking") {

--- a/src/hooks/ClientCmd_Unrestricted.cpp
+++ b/src/hooks/ClientCmd_Unrestricted.cpp
@@ -1,0 +1,44 @@
+#include "HookedMethods.hpp"
+#include "MiscTemporary.hpp"
+#include "CatBot.hpp"
+#include "interfaces.hpp"
+#include "ipc.hpp"
+namespace hooked_methods
+{
+
+DEFINE_HOOKED_METHOD(ClientCmd_Unrestricted, void, IVEngineClient013* _this, const char* command)
+{
+    if (hacks::shared::catbot::abandon_if_ipc_bots_gte) {
+        std::string command_str(command);
+        
+        if (ipc::peer && command_str.length() >= 20 && command_str.substr(0, 7) == "connect") {
+            unsigned count_ipc = 0;
+
+            if (command_str.substr(command_str.length() - 11, 11) == "matchmaking") {
+                std::string server_ip = command_str.substr(8, command_str.length() - 20);
+
+                auto &peer_mem = ipc::peer->memory;
+
+                for (unsigned i = 0; i < cat_ipc::max_peers; i++) {
+                    if (i != ipc::peer->client_id && !peer_mem->peer_data[i].free && peer_mem->peer_user_data[i].connected && peer_mem->peer_user_data[i].ingame.server) {
+
+                        std::string remote_server_ip(peer_mem->peer_user_data[i].ingame.server);
+                        if (remote_server_ip.compare(server_ip) == 0) {
+                            count_ipc++;
+                        }
+                    }
+                }
+            }
+
+            if (count_ipc > 0 && count_ipc >= (int)hacks::shared::catbot::abandon_if_ipc_bots_gte)
+            {
+                // if (hacks::shared::catbot::auto-requeue)
+                tfmm::startQueue();
+                return;
+            }
+        }
+    }
+
+    original::ClientCmd_Unrestricted(_this, command);
+}
+} // namespace hooked_methods


### PR DESCRIPTION
Don't connect if catbots already in the server (reads abandon-if-bots-ipc) and don't count self when checking count_ipc