### PR TITLE
Autobuild binary mode packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,26 @@
+# File responsible for building the cathook "binary package"
+
+image: "nullworks/cathook-ci-ubuntu:latest"
+
+variables:
+    GIT_SUBMODULE_STRATEGY: recursive
+stages:
+  - build
+
+pages:
+  script:
+    # Build cathook
+    - mkdir build_cathook && pushd build_cathook && cmake .. && make && popd
+    # Create the "package" containing everything needed
+    - mkdir package && mv ./bin/libcathook.so ./package/libcathook.so && mv ./data ./package/data && mv ./config_data ./package/config_data && mv ./scripts/binarypackage/install ./package/install && mv ./scripts/binarypackage/attach ./package/attach
+    # Build a static gdb
+    - mkdir build_gdb && pushd build_gdb && wget http://ftp.gnu.org/gnu/gdb/gdb-9.1.tar.xz -O gdb.tar.xz && tar xf gdb.tar.xz --strip-components 1 && mkdir build && pushd build && ../configure --prefix=<> --enable-static=yes --enable-inprocess-agent=no CFLAGS="-static -Os -s" CXXFLAGS="-Os -s -static" && make && popd && popd
+    # Create public directory
+    - mkdir public && tar -czf ./public/package.tar.gz ./package/ && mv ./build_gdb/build/gdb/gdb ./public/gdb
+  artifacts:
+    paths:
+    - public
+    expire_in: 1 weeks
+  stage: build
+  only:
+    - stable

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ stages:
 pages:
   script:
     # Build cathook
-    - mkdir build_cathook && pushd build_cathook && cmake .. && make && popd
+    - mkdir build_cathook && pushd build_cathook && cmake -DInternal_Binarymode=true .. && make && popd
     # Create the "package" containing everything needed
     - mkdir package && mv ./bin/libcathook.so ./package/libcathook.so && mv ./data ./package/data && mv ./config_data ./package/config_data && mv ./scripts/binarypackage/install ./package/install && mv ./scripts/binarypackage/attach ./package/attach
     # Build a static gdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ if (EnableCotire)
     set(ignore_files ${ignore_files} CACHE INTERNAL "")
 endif()
 
+#
+# Config stuff
+#
+
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type")
 endif()
@@ -90,10 +94,22 @@ set(EnableNullNexus 1 CACHE BOOL "Enable NullNexus chat and other features")
 set(EnableLogging 1 CACHE BOOL "Enable logging to /tmp/")
 set(EnableClip 1 CACHE BOOL "Enable anti electron/chromium freezing")
 set(Unity_ZeroKernel 1 CACHE BOOL "Use a unity build for zerokernel files")
-
 if(NOT EnableVisuals)
     set(EnableGUI 0)
 endif()
+
+# Internal variables
+# INTERNAL implies "FORCE" by default, so don't set if already set
+if (NOT DEFINED Internal_Binarymode)
+    set(Internal_Binarymode 0 CACHE INTERNAL "Build cathook to be used in 'binary mode'")
+endif()
+if (NOT DEFINED Internal_Symbolized)
+    set(Internal_Symbolized 0 CACHE INTERNAL "Build cathook with symbols so crashes can be sent")
+endif()
+
+#
+# End of config stuff
+#
 
 if (EnableVisuals)
     set(OpenGL_GL_PREFERENCE "LEGACY")
@@ -167,7 +183,7 @@ configure_file(include/version.h.in ${CMAKE_SOURCE_DIR}/include/version.h @ONLY)
 
 set(CMAKE_CXX_FLAGS "-m32 -march=native -fexceptions -fno-gnu-unique -DNDEBUG")
 set(CMAKE_CXX_FLAGS_DEBUG "-rdynamic -ggdb -Og")
-if (symbolize)
+if (Internal_Symbolized)
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ggdb -fvisibility=hidden -fvisibility-inlines-hidden")
 else()
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -s -fvisibility=hidden -fvisibility-inlines-hidden")
@@ -231,12 +247,12 @@ elseif(EnablePrecompiledHeaders AND NativePrecompiledHeaders)
     target_precompile_headers(cathook PRIVATE "${CMAKE_SOURCE_DIR}/include/common.hpp")
 endif()
 
-if (NOT symbolize)
+if (NOT Internal_Symbolized)
     add_custom_command(TARGET cathook POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cathook> "${CMAKE_SOURCE_DIR}/bin/$<TARGET_FILE_NAME:cathook>")
 else()
     message("Symbolized build")
-    unset(symbolize CACHE)
+    set(Internal_Symbolized 0 CACHE INTERNAL "Build cathook with symbols so crashes can be sent" FORCE)
 endif()
 if (EnableCotire)
     add_custom_command(TARGET cathook_unity POST_BUILD

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -11,6 +11,7 @@
 #define ENABLE_VAC_BYPASS @VACBypass@
 #define ENABLE_TEXTMODE_STDIN @EnableTextmodeStdin@
 #define ENABLE_TEXTMODE @Textmode@
+#define ENABLE_BINARYMODE @Internal_Binarymode@
 #define ENABLE_PROFILER @EnableProfiler@
 #define ENABLE_NULLNEXUS @EnableNullNexus@
 #define ENABLE_LOGGING @EnableLogging@

--- a/report-crash
+++ b/report-crash
@@ -80,7 +80,7 @@ if [ $SYMBOLS == false ]; then
     proccount=$(grep -c '^processor' /proc/cpuinfo)
     \cp ./build/CMakeCache.txt ./scripts/CMakeCacheBackup.txt
     pushd build
-    cmake -Dsymbolize=true .. && cmake --build . --target cathook -- -j$proccount
+    cmake -DInternal_Symbolized=true .. && cmake --build . --target cathook -- -j$proccount
     popd
 fi
 

--- a/scripts/binarypackage/attach
+++ b/scripts/binarypackage/attach
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Error codes:
+# 1 Generic
+# 2 TF2 not running
+
+set -e
+
+[[ ! -z "$SUDO_USER" ]] && RUNUSER="$SUDO_USER" || RUNUSER="$LOGNAME"
+
+line=$(pgrep -u $RUNUSER hl2_linux || true)
+arr=($line)
+
+if [ $# == 1 ]; then
+    proc=$1
+else
+    if [ ${#arr[@]} == 0 ]; then
+        echo TF2 isn\'t running!
+        exit 2
+    fi
+    proc=${arr[0]}
+fi
+
+echo Running instances: "${arr[@]}"
+echo Attaching to "$proc"
+
+#sudo ./detach $inst bin/libcathook.so
+
+#if grep -q "$(realpath bin/libcathook.so)" /proc/"$proc"/maps; then
+#  echo already loaded
+#  exit
+#fi
+
+# pBypass for crash dumps being sent
+# You may also want to consider using -nobreakpad in your launch options.
+mkdir -p /tmp/dumps # Make it as root if it doesnt exist
+chown root:root /tmp/dumps # Claim it as root
+chmod 000 /tmp/dumps # No permissions
+
+FILENAME="/tmp/.gl$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 6)"
+
+cp "libcathook.so" "$FILENAME"
+
+echo loading "$FILENAME" to "$proc"
+
+
+gdbbin="gdb"
+if ! [ -x "$(command -v gdb)" ]; then
+  gdbbin="../gdb"
+  chmod +x "$gdbbin"
+fi
+
+$gdbbin -n -q -batch \
+    -ex "attach $proc" \
+    -ex "set \$dlopen = (void*(*)(char*, int)) dlopen" \
+    -ex "call \$dlopen(\"$FILENAME\", 1)" \
+    -ex "call dlerror()" \
+    -ex 'print (char *) $2' \
+    -ex "detach" \
+    -ex "quit"
+
+rm $FILENAME

--- a/scripts/binarypackage/install
+++ b/scripts/binarypackage/install
@@ -1,0 +1,3 @@
+#!/bin/bash
+\cp -rf ./data/ ../
+\cp -nr ./config_data/* ../data

--- a/scripts/binarypackage/readme
+++ b/scripts/binarypackage/readme
@@ -1,0 +1,1 @@
+Just some scripts used by the "binary" version of cathook available in cathook-gui. Ignore this if you are just using cathook.

--- a/src/pathio.cpp
+++ b/src/pathio.cpp
@@ -19,27 +19,25 @@ std::string getDataPath(std::string subpath)
 {
     if (!cached_data_path)
     {
-        DIR *dir;
         if (std::getenv("CH_DATA_PATH"))
         {
             cached_data_path = std::getenv("CH_DATA_PATH");
         }
-        else if ((dir = opendir(DATA_PATH)))
-        {
-            cached_data_path = DATA_PATH;
-            closedir(dir);
-        }
         else
         {
+#if ENABLE_BINARYMODE
             std::string xdg_data_dir;
             if (std::getenv("XDG_DATA_HOME"))
                 xdg_data_dir = std::getenv("XDG_DATA_HOME");
             else if (std::getenv("HOME"))
                 xdg_data_dir = std::string(std::getenv("HOME")) + "/.local/share";
+            if (xdg_data_dir.empty())
+                cached_data_path = DATA_PATH;
             else
-                xdg_data_dir = DATA_PATH;
-            cached_data_path = xdg_data_dir + "/cathook/data";
-            logging::Info("Data path: %s", cached_data_path->c_str());
+                cached_data_path = xdg_data_dir + "/cathook/data";
+#else
+            cached_data_path = DATA_PATH;
+#endif
         }
     }
     return *cached_data_path + subpath;


### PR DESCRIPTION
The next cathook-gui update will re-enable binary mode! This lays the foundation and auto builds the binary mode packages every time stable is updated.

Also requesting permission to backport to stable for obvious reasons.
- [x]  <- Permission