### PR TITLE
Fixed dependencies on gentoo

### DIFF
--- a/scripts/dependencycheck
+++ b/scripts/dependencycheck
@@ -78,7 +78,7 @@ case "$OS" in
     "gentoo")
         requestPermissions "${gentoo_packages[@]}"
         # -U (--newuse): Installed packages that have no changes are excluded.
-        USE=abi_x86_32 $SUDO emerge -avU "${gentoo_packages[@]}"
+        USE=abi_x86_32 $SUDO emerge -vU "${gentoo_packages[@]}"
     ;;
     "arch")
         pacman -Qi "${arch_packages[@]}" > /dev/null 2>&1


### PR DESCRIPTION
Emerge freaks out and refuses to install dependencies if -a is asked in a script. Removing it should fix the issues