### PR TITLE
Fix aiming at buildings

### DIFF
--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -1142,9 +1142,7 @@ const Vector &PredictEntity(CachedEntity *entity)
         // NPCs (Skeletons, merasmus, etc)
         else if (entity->m_Type() == ENTITY_NPC)
         {
-            auto mins = RAW_ENT(entity)->GetCollideable()->OBBMins();
-            auto maxs = RAW_ENT(entity)->GetCollideable()->OBBMaxs();
-            result    = RAW_ENT(entity)->GetCollideable()->GetCollisionOrigin() + (mins + maxs) / 2.0f;
+            result = entity->hitboxes.GetHitbox(std::max(0, entity->hitboxes.GetNumHitboxes() / 2 - 1))->center;
         }
         // Other
         else

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -1075,12 +1075,7 @@ bool VisCheckEntFromEntVector(Vector startVector, CachedEntity *startEnt, Cached
 
 Vector GetBuildingPosition(CachedEntity *ent)
 {
-    // Get the collideable origin of ent and get min and max of collideable
-    // OBBMins and OBBMaxs are offsets from origin
-    auto raw = RAW_ENT(ent);
-    Vector min, max;
-    raw->GetRenderBounds(min, max);
-    return (min + max) / 2 + raw->GetCollideable()->GetCollisionOrigin();
+    return ent->hitboxes.GetHitbox(std::max(0, ent->hitboxes.GetNumHitboxes() / 2 - 1))->center;
 }
 
 bool IsBuildingVisible(CachedEntity *ent)


### PR DESCRIPTION
Render bounds stretch under the floor for some reason, and apparently those npcs do have proper hitboxes we can aim at, so do it
![image](https://user-images.githubusercontent.com/13179138/97781611-f5e92200-1b8c-11eb-8e27-0a76badf617b.png)

^this is what it tried to aim at before, which occasionally (especially on teleporters) lead to alot of issues. It now aims at the middle most hitbox, which also makes aiming at sentries more reliable.