### PR TITLE
Fix a autoitem and a chams bug

### DIFF
--- a/src/hacks/AutoItem.cpp
+++ b/src/hacks/AutoItem.cpp
@@ -145,6 +145,9 @@ static bool equipItem(int clazz, int slot, int id, bool get = true, bool allowRe
             slot = 6;
     }
 
+    if (id == -1)
+        return invmng->EquipItemInLoadout(clazz, slot, -1);
+
     if (get)
     {
         auto item_view = inv->GetFirstItemOfItemDef(id);
@@ -154,9 +157,6 @@ static bool equipItem(int clazz, int slot, int id, bool get = true, bool allowRe
             return false;
         }
     }
-    if (id == -1)
-        return invmng->EquipItemInLoadout(clazz, slot, -1);
-
     auto item_view = inv->GetFirstItemOfItemDef(id);
     if (item_view)
         return invmng->EquipItemInLoadout(clazz, slot, item_view->UUID());

--- a/src/hooks/visual/DrawModelExecute.cpp
+++ b/src/hooks/visual/DrawModelExecute.cpp
@@ -259,8 +259,8 @@ bool ShouldRenderChams(IClientEntity *entity)
     if (entity->entindex() < 0)
         return false;
     CachedEntity *ent = ENTITY(entity->entindex());
-    if (chamsself && ent->m_IDX == LOCAL_E->m_IDX)
-        return true;
+    if (ent->m_IDX == LOCAL_E->m_IDX)
+        return *chamsself;
     switch (ent->m_Type())
     {
     case ENTITY_BUILDING:


### PR DESCRIPTION
Autoitem would not work with '-1' because it would try to get the item.
Chams would still apply local player cham with teammates on and local player off.