### PR TITLE
Remove cotire & projectile silent

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,9 +16,6 @@
 [submodule "external/TF2_NavFile_Reader"]
 	path = external/TF2_NavFile_Reader
 	url = https://github.com/nullworks/TF2_NavFile_Reader
-[submodule "external/cotire"]
-	path = external/cotire
-	url = https://github.com/sakra/cotire
 [submodule "external/clip"]
 	path = external/clip
 	url = https://github.com/nullworks/clip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 set(EnablePrecompiledHeaders 1 CACHE BOOL "Enable Precompiled Headers to reduce compile time")
 if(${CMAKE_VERSION} VERSION_LESS "3.16.0")
-    set(EnableCotire 1 CACHE BOOL "Enable CoTiRe (Compile Time Reducer)")
     unset(NativePrecompiledHeaders)
 else()
     set(NativePrecompiledHeaders 1)
@@ -11,26 +10,6 @@ endif()
 
 # Ensure that only 32 bit libraries are used.
 set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/Toolchain-cross-m32.cmake")
-
-if (EnableCotire)
-    # Don't enable cotire when running in QtCreator
-    execute_process(COMMAND "printenv" OUTPUT_VARIABLE contents)
-    STRING(REGEX REPLACE ";" "\\\\;" contents "${contents}")
-    STRING(REGEX REPLACE "\n" ";" contents "${contents}")
-    foreach(text ${contents})
-        if ("${text}"  STREQUAL "CC=")
-            message("qtcreator running")
-            set(EnableCotire 0)
-        endif()
-    endforeach()
-endif()
-
-if (EnableCotire)
-    set (CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/external/cotire/CMake")
-    include(cotire)
-    file(GLOB_RECURSE ignore_files *.cpp)
-    set(ignore_files ${ignore_files} CACHE INTERNAL "")
-endif()
 
 #
 # Config stuff
@@ -233,17 +212,7 @@ add_subdirectory(include)
 add_subdirectory(external)
 add_subdirectory(modules)
 
-if (EnableCotire)
-    if (EnablePrecompiledHeaders)
-        set_target_properties(cathook PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT "${CMAKE_SOURCE_DIR}/include/common.hpp")
-    else()
-        set_target_properties(cathook PROPERTIES COTIRE_ENABLE_PRECOMPILED_HEADER FALSE)
-    endif()
-    set_target_properties(cathook PROPERTIES COTIRE_ADD_UNITY_BUILD true)
-    set_target_properties(cathook PROPERTIES COTIRE_UNITY_SOURCE_MAXIMUM_NUMBER_OF_INCLUDES 30)
-    set_source_files_properties(${ignore_files} PROPERTIES COTIRE_EXCLUDED true)
-    cotire(cathook)
-elseif(EnablePrecompiledHeaders AND NativePrecompiledHeaders)
+if(EnablePrecompiledHeaders AND NativePrecompiledHeaders)
     target_precompile_headers(cathook PRIVATE "${CMAKE_SOURCE_DIR}/include/common.hpp")
 endif()
 
@@ -253,8 +222,4 @@ if (NOT Internal_Symbolized)
 else()
     message("Symbolized build")
     set(Internal_Symbolized 0 CACHE INTERNAL "Build cathook with symbols so crashes can be sent" FORCE)
-endif()
-if (EnableCotire)
-    add_custom_command(TARGET cathook_unity POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:cathook_unity> "${CMAKE_SOURCE_DIR}/bin/$<TARGET_FILE_NAME:cathook_unity>")
 endif()

--- a/data/menu/nullifiedcat/weapons/aimbot.xml
+++ b/data/menu/nullifiedcat/weapons/aimbot.xml
@@ -26,7 +26,6 @@
         <List width="150">
             <AutoVariable width="fill" target="aimbot.projectile.enable" label="Enable projectile aimbot"/>
             <AutoVariable width="fill" target="misc.auto-flip-viewmodel" label="Flip Viewmodel" tooltip="Automatically flip the viewmodel for projectile weapons."/>
-            <AutoVariable width="fill" target="aimbot.projectile-silent" label="pSilent" tooltip="Stops snapping of projectile weapons on the screen of others."/>
             <AutoVariable width="fill" target="aimbot.projectile.gravity" label="Gravity override"/>
             <AutoVariable width="fill" target="aimbot.projectile.initial-velocity" label="Initial Velocity"/>
             <AutoVariable width="fill" target="aimbot.projectile.speed" label="Velocity override"/>

--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -32,7 +32,6 @@ static settings::Float normal_fov{ "aimbot.fov", "0" };
 static settings::Int priority_mode{ "aimbot.priority-mode", "0" };
 static settings::Boolean wait_for_charge{ "aimbot.wait-for-charge", "0" };
 
-static settings::Boolean proj_silent("aimbot.projectile-silent", "1");
 static settings::Boolean silent{ "aimbot.silent", "1" };
 static settings::Boolean target_lock{ "aimbot.lock-target", "0" };
 #if ENABLE_VISUALS
@@ -1009,9 +1008,6 @@ void DoAutoshoot(CachedEntity *target_entity)
             current_user_cmd->buttons &= ~IN_ATTACK;
             hacks::shared::antiaim::SetSafeSpace(5);
             begancharge = false;
-            // Projectile silent logic
-            if (proj_silent)
-                *bSendPackets = false;
         }
         // Pull string if charge isnt enough
         else
@@ -1035,9 +1031,6 @@ void DoAutoshoot(CachedEntity *target_entity)
             current_user_cmd->buttons &= ~IN_ATTACK;
             hacks::shared::antiaim::SetSafeSpace(5);
             begansticky = 0;
-            // Projectile silent logic
-            if (proj_silent)
-                *bSendPackets = false;
         }
         // Else just keep charging
         else
@@ -1094,11 +1087,7 @@ void DoAutoshoot(CachedEntity *target_entity)
             auto hitbox = calculated_data_array[target_entity->m_IDX].hitbox;
             hitrate::AimbotShot(target_entity->m_IDX, hitbox != head);
         }
-        // Projectile silent logic
-        if (projectileAimbotRequired && proj_silent)
-            *bSendPackets = false;
-        else
-            *bSendPackets = true;
+        *bSendPackets = true;
     }
     if (LOCAL_W->m_iClassID() == CL_CLASS(CTFLaserPointer))
         current_user_cmd->buttons |= IN_ATTACK2;


### PR DESCRIPTION
1. Ubuntu 18.04 users are rarer than ever before. Not worth it to keep deprecated software around. Cathook will still work for them, it will just compile slower.
2. Projectile silent was removed at the request of @BenCat07