### PR TITLE
Add melee mode to navbot

### DIFF
--- a/data/menu/nullifiedcat/movement.xml
+++ b/data/menu/nullifiedcat/movement.xml
@@ -35,15 +35,13 @@
             <AutoVariable width="fill" target="nav.look-at-path" label="Look at path"/>
             <AutoVariable width="fill" target="navbot.enabled" label="Enable NavBot"/>
             <AutoVariable width="fill" target="navbot.capture-objectives" label="Capture objectives" tooltip="Automatically capture objectives (CTF,CP and PL only)"/>
-            <!--AutoVariable width="fill" target="navbot.engineer-mode" label="Enable Engineer mode"/-->
             <AutoVariable width="fill" target="navbot.search-health" label="Search health"/>
             <AutoVariable width="fill" target="navbot.search-ammo" label="Search ammo"/>
             <AutoVariable width="fill" target="navbot.escape-danger" label="Escape danger"/>
             <AutoVariable width="fill" target="navbot.escape-danger.slight-danger.capping" label="Safe capping" tooltip="Make bots run pre-emptively from capture points in case of danger"/>
             <AutoVariable width="fill" target="navbot.escape-danger.ctf-cap" label="Escape danger w. intel" tooltip="Also try to escape from danger when carrying intel."/>
-            <!--AutoVariable width="fill" target="navbot.spy-mode" label="Enable Spy mode"/>
-            <AutoVariable width="fill" target="navbot.other-mode" label="General mode"/-->
-            <AutoVariable width="fill" target="navbot.primary-only" label="Best weapon only"/>
+            <AutoVariable width="fill" target="navbot.primary-only" label="Auto best weapon"/>
+            <AutoVariable width="fill" target="navbot.melee-mode" label="Melee only"/>
             <AutoVariable width="fill" target="navbot.autojump.enabled" label="Enable autojump"/>
             <AutoVariable width="fill" target="navbot.autojump.trigger-distance" label="Jump distance"/>
             <AutoVariable width="fill" target="navbot.snipe-sentries" label="Try to target sentries"/>

--- a/include/navparser.hpp
+++ b/include/navparser.hpp
@@ -4,6 +4,9 @@
 #include <vector>
 #include "CNavFile.h"
 
+// 1. Who the fuck put this in navparser.hpp
+// 2. Why the fuck is it outside of all namespaces
+// 3. There's a conflict between melee and prio_melee in navbot.cpp, so it needs to be named differently
 enum Priority_list
 {
     patrol = 5,
@@ -13,6 +16,7 @@ enum Priority_list
     followbot,
     ammo,
     capture,
+    prio_melee,
     health,
     danger,
 };


### PR DESCRIPTION
This doesn't just add the melee mode variable, it also adds a full melee AI that will kick in whenever a bot is using a melee weapon. This could easily be used to make bots counter fist of steal heavies for example, by simply making the bot switch to melee in getBestSlot.