### PR TITLE
Make teammate buildings option work correctly

### DIFF
--- a/src/visual/EffectGlow.cpp
+++ b/src/visual/EffectGlow.cpp
@@ -279,7 +279,7 @@ bool EffectGlow::ShouldRenderGlow(IClientEntity *entity)
     case ENTITY_BUILDING:
         if (!buildings)
             return false;
-        if (!ent->m_bEnemy() && !(teammate_buildings || teammates))
+        if (!ent->m_bEnemy() && !teammate_buildings)
             return false;
         if (CE_BYTE(LOCAL_E, netvar.m_bCarryingObject) && ent->m_IDX == HandleToIDX(CE_INT(LOCAL_E, netvar.m_hCarriedObject)))
             return false;


### PR DESCRIPTION
Before there was no way to have glow for teammates and enemy buildings but not team buildings. Also, I can recreate the config UI if you are interested.