### PR TITLE
Add zoom key

### DIFF
--- a/data/menu/nullifiedcat/visuals/world.xml
+++ b/data/menu/nullifiedcat/visuals/world.xml
@@ -14,9 +14,15 @@
     <Box padding="12 6 6 6" width="content" height="content" name="Thirdperson" y="110">
         <List width="180">
             <AutoVariable width="fill" target="visual.thirdperson.enable" label="Enable Thirdperson"/>
-        <AutoVariable width="fill" target="visual.thirdperson-button" label="Thirdperson Button" tooltip="Set a Button to Toggle Thirdperson"/>
+            <AutoVariable width="fill" target="visual.thirdperson-button" label="Thirdperson Button" tooltip="Set a Button to Toggle Thirdperson"/>
             <AutoVariable width="fill" target="visual.thirdperson.real-angles" label="Show Angles in Thirdperson" tooltip="Show Real Antiaim Angles in Third Person"/>
-        <AutoVariable width="fill" target="visual.thirdperson.disable-zoomed" label="Disable When Zoomed" tooltip="Disables Thirdperson When Zoomed In"/>
+            <AutoVariable width="fill" target="visual.thirdperson.disable-zoomed" label="Disable When Zoomed" tooltip="Disables Thirdperson When Zoomed In"/>
+        </List>
+    </Box>
+    <Box padding="12 6 6 6" width="content" height="content" name="Zooming" y="190">
+        <List width="180">
+            <AutoVariable width="fill" target="visual.zoom-key" label="Zoom key"/>
+            <AutoVariable width="fill" target="visual.zoom-key.fov" label="Zoom FOV"/>
         </List>
     </Box>
     <Box padding="12 6 6 6" width="content" height="content" name="Remove" x="195">

--- a/include/sdk/HUD.h
+++ b/include/sdk/HUD.h
@@ -35,4 +35,5 @@ public:
     void *vtable;
 
     CHudElement *FindElement(const char *name);
+    float &GetSensitivityFactor();
 };

--- a/src/sdk/HUD.cpp
+++ b/src/sdk/HUD.cpp
@@ -21,3 +21,7 @@ CHudElement *CHud::FindElement(const char *name)
     ((FindElement)(findel_sig))(this, name);
     return ((FindElement)(findel_sig))(this, name);
 }
+float &CHud::GetSensitivityFactor()
+{
+    return *(float *) ((uintptr_t) this + 8);
+}


### PR DESCRIPTION
Just add a way to zoom in without a sniper scope, useful if you want to shoot someone from far away with a projectile for example, or just to check out what's going on in that direction.