### PR TITLE
Aimbot coloring option

### DIFF
--- a/data/menu/nullifiedcat/visuals/chams.xml
+++ b/data/menu/nullifiedcat/visuals/chams.xml
@@ -7,6 +7,7 @@
                     <AutoVariable width="fill" target="chams.legit" label="Legit" tooltip="Don't show chams through walls."/>
                     <AutoVariable width="fill" target="chams.health" label="Health" tooltip="Color chams according to player health."/>
                     <AutoVariable width="fill" target="chams.recursive" label="Recursive"/>
+                    <AutoVariable width="fill" target="chams.aimbot.color" label="Aimbot coloring" tooltip="Color the aimbot's target according to color set in Visual:Colors"/>
                     <AutoVariable width="fill" target="chams.novis" label="Use seperate novis colors" tooltip="Seperate colors when a entity is not visible"/>
                     <AutoVariable width="fill" target="chams.weapons" label="Weapon chams seperate color" tooltip="Color weapons."/>
                     <AutoVariable width="fill" target="chams.local-weapon" label="Local weapon chams" tooltip="Cham your first person weapon"/>

--- a/data/menu/nullifiedcat/visuals/glow.xml
+++ b/data/menu/nullifiedcat/visuals/glow.xml
@@ -4,7 +4,8 @@
             <AutoVariable width="fill" target="glow.enable" label="Enable glow"/>
             <AutoVariable width="fill" target="glow.blur-scale" label="Blur scale" min="1" max="20"/>
             <AutoVariable width="fill" target="glow.health" label="Health" tooltip="Color glow according to player health."/>
-            <LabeledObject width="fill" label="Solid When">
+            <AutoVariable width="fill" target="glow.aimbot.color" label="Aimbot coloring" tooltip="Color the aimbot's target according to color set in Visual:Colors"/>
+            <LabeledObject width="fill" label="Solid when">
                 <Select target="glow.solid-when">
                     <Option name="Never" value="0"/>
                     <Option name="Always" value="1"/>

--- a/src/hooks/visual/DrawModelExecute.cpp
+++ b/src/hooks/visual/DrawModelExecute.cpp
@@ -35,6 +35,7 @@ static settings::Boolean render_original{ "chams.original", "false" };
 
 /* Cham target rvars */
 static settings::Boolean health{ "chams.health", "false" };
+static settings::Boolean aimbot_color{ "chams.aimbot.color", "true" };
 static settings::Boolean teammates{ "chams.show.teammates", "false" };
 static settings::Boolean disguised{ "chams.show.disguised", "true" };
 static settings::Boolean players{ "chams.show.players", "true" };
@@ -335,7 +336,7 @@ static ChamColors GetChamColors(IClientEntity *entity, bool ignorez)
 
     if (CE_BAD(ent))
         return ChamColors(colors::white);
-    if (ent == hacks::shared::aimbot::CurrentTarget())
+    if (ent == hacks::shared::aimbot::CurrentTarget() && aimbot_color)
         return ChamColors(colors::target);
     if (re::C_BaseCombatWeapon::IsBaseCombatWeapon(entity))
     {

--- a/src/visual/EffectGlow.cpp
+++ b/src/visual/EffectGlow.cpp
@@ -30,6 +30,7 @@ namespace effect_glow
 {
 
 static settings::Boolean health{ "glow.health", "false" };
+static settings::Boolean aimbot_color{ "glow.aimbot.color", "true" };
 static settings::Boolean teammates{ "glow.show.teammates", "false" };
 static settings::Boolean disguised{ "glow.show.disguised", "true" };
 static settings::Boolean players{ "glow.show.players", "true" };
@@ -229,7 +230,7 @@ rgba_t EffectGlow::GlowColor(IClientEntity *entity)
     ent = ENTITY(entity->entindex());
     if (CE_BAD(ent))
         return colors::white;
-    if (ent == hacks::shared::aimbot::CurrentTarget())
+    if (ent == hacks::shared::aimbot::CurrentTarget() && aimbot_color)
         return colors::target;
     if (re::C_BaseCombatWeapon::IsBaseCombatWeapon(entity))
     {


### PR DESCRIPTION
This pull request allows the coloring of the aimbot's target (set in Visuals:Colors) to be disabled for chams and glow.