### PR TITLE
Set secure directory permissions for cathook data directory

### DIFF
--- a/install-data
+++ b/install-data
@@ -8,11 +8,11 @@ if ! [ -d "$DATA_PATH" ]; then
     echo "Creating cathook data directory at $DATA_PATH"
     mkdir -p "$DATA_PATH"
     chown -R $user "$DATA_PATH"
-    chmod -R 777 "$DATA_PATH"
+    chmod -R 774 "$DATA_PATH"
 fi
 
 echo "Installing cathook data to $DATA_PATH"
 rsync -avh "data/" "$DATA_PATH"
 rsync -avh --ignore-existing "config_data/" "$DATA_PATH"
 chown -R $user "$DATA_PATH"
-chmod -R 777 "$DATA_PATH"
+chmod -R 774 "$DATA_PATH"


### PR DESCRIPTION
I don't think I need to explain why having **world** executable, writable, and readable permissions from any user is extremely unsafe and you would be fired for doing that at any job.

As far as I know, there is not another user that needs to interact with those directories that isn't the current one you're launching Steam, playing TF2, and compiling cathook from. While I would set it to world 0, I'm not 100% confident any other user may need to read this directory, and usually the umask for most standard systems is 002 so we'll just take the world writable out.

Lots and lots of servers dedicated to cathook bots currently suffer from this flaw if an unprivileged user has access to their system.

The directory in question is `/opt/cathook/data`