### PR TITLE
Add curl to dependency lists

### DIFF
--- a/scripts/dependencycheck
+++ b/scripts/dependencycheck
@@ -6,11 +6,11 @@ GIT=${1:-false}
 SUDO=${CH_SUDO:-sudo}
 FORCEYES=${CH_DEPENDENCYCHECK_FORCEYES:-false}
 
-gentoo_packages=(dev-vcs/git dev-libs/boost dev-util/cmake sys-devel/gcc sys-devel/gdb media-libs/libsdl2 media-libs/glew media-libs/freetype net-misc/rsync media-libs/libglvnd dev-util/dialog)
-arch_packages=(git boost cmake make gcc gdb lib32-sdl2 lib32-glew lib32-freetype2 rsync lib32-libglvnd dialog)
-ubuntu_packages=(build-essential git g++ g++-multilib libboost-dev gdb libsdl2-dev:i386 libfreetype6-dev:i386 cmake dialog rsync)
-fedora_packages=(cmake dialog make gcc-c++ glibc-devel.i686 freetype-devel.i686 SDL2-devel.i686 glew-devel.i686 boost-devel rsync gdb git)
-void_packages=(git gcc gdb gcc-multilib boost boost-devel-32bit SDL2-devel-32bit glew-devel-32bit freetype-devel-32bit libglvnd-devel-32bit rsync)
+gentoo_packages=(dev-vcs/git dev-libs/boost dev-util/cmake sys-devel/gcc sys-devel/gdb media-libs/libsdl2 media-libs/glew media-libs/freetype net-misc/rsync media-libs/libglvnd dev-util/dialog net-misc/curl)
+arch_packages=(git boost cmake make gcc gdb lib32-sdl2 lib32-glew lib32-freetype2 rsync lib32-libglvnd dialog curl)
+ubuntu_packages=(build-essential git g++ g++-multilib libboost-dev gdb libsdl2-dev:i386 libfreetype6-dev:i386 cmake dialog rsync curl)
+fedora_packages=(cmake dialog make gcc-c++ glibc-devel.i686 freetype-devel.i686 SDL2-devel.i686 glew-devel.i686 boost-devel rsync gdb git curl)
+void_packages=(git gcc gdb gcc-multilib boost boost-devel-32bit SDL2-devel-32bit glew-devel-32bit freetype-devel-32bit libglvnd-devel-32bit rsync curl)
 
 # Check if we should only install git
 if [ "$GIT" == true ]; then


### PR DESCRIPTION
Arch uses curl to download gdb binary, submitting crash reports use curl, and migrations use curl. I've found curl to not be installed by default usually.