### PR TITLE
Do not steal medpacks if being healed

### DIFF
--- a/src/hacks/NavBot.cpp
+++ b/src/hacks/NavBot.cpp
@@ -63,6 +63,10 @@ static Timer ammo_cooldown{};
 // Should we search health at all?
 bool shouldSearchHealth(bool low_priority = false)
 {
+    // Check if being gradually healed in any way
+    if (HasCondition<TFCond_Healing>(LOCAL_E))
+        return false;
+
     // Priority too high
     if (navparser::NavEngine::current_priority > health)
         return false;


### PR DESCRIPTION
Signed-off-by: Ashley <ash@trapacid.dev>

Partially solves https://github.com/nullworks/cathook/issues/1375
TFCond_Healing applies to any sort of gradual healing.