### PR TITLE
#701 fix & gitignore changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -290,3 +290,5 @@ scripts/updater-preferences
 
 *.autosave
 
+# clangd
+.cache

--- a/include/hacks/AntiAim.hpp
+++ b/include/hacks/AntiAim.hpp
@@ -6,6 +6,7 @@
  */
 
 #pragma once
+#include <inetmessage.h>
 
 class CUserCmd;
 
@@ -17,4 +18,5 @@ void SetSafeSpace(int safespace);
 bool ShouldAA(CUserCmd *cmd);
 void ProcessUserCmd(CUserCmd *cmd);
 bool isEnabled();
+void SendNetMessage(INetMessage &msg);
 } // namespace hacks::shared::antiaim

--- a/src/hacks/AntiAim.cpp
+++ b/src/hacks/AntiAim.cpp
@@ -10,7 +10,6 @@
 #include <hacks/AntiAim.hpp>
 
 #include "common.hpp"
-
 namespace hacks::shared::antiaim
 {
 bool force_fakelag = false;
@@ -199,6 +198,25 @@ void SetSafeSpace(int safespace)
         safe_space = safespace;
 }
 
+/* checks if action slot is being used */
+void SendNetMessage(INetMessage &msg)
+{
+    if (!enable)
+        return;
+
+    if(!((KeyValues *) (((unsigned *) &msg)[4])))
+        return;
+
+    auto name = ((KeyValues *) (((unsigned *) &msg)[4]))->GetName();
+
+    if (CE_BAD(LOCAL_E))
+        return;
+
+    /* checks if action slot has been used & grapple is equipped */
+    if (!strcmp(name, "+use_action_slot_item_server") && HasWeapon(LOCAL_E, 1152))
+        SetSafeSpace(2);
+}
+
 bool ShouldAA(CUserCmd *cmd)
 {
     if (hacks::tf2::antibackstab::noaa)
@@ -213,6 +231,10 @@ bool ShouldAA(CUserCmd *cmd)
     }
     if ((cmd->buttons & IN_ATTACK2) && classid == CL_CLASS(CTFLunchBox))
         return false;
+    if ((cmd->buttons & IN_ATTACK) && classid == CL_CLASS(CTFGrapplingHook) && !g_pLocalPlayer->bAttackLastTick)
+    {
+        SetSafeSpace(2);
+    }
     switch (mode)
     {
     case weapon_projectile:

--- a/src/hooks/SendNetMsg.cpp
+++ b/src/hooks/SendNetMsg.cpp
@@ -5,6 +5,7 @@
 
 #include <MiscTemporary.hpp>
 #include <settings/Int.hpp>
+#include "AntiAim.hpp"
 #include "HookedMethods.hpp"
 #include <MiscTemporary.hpp>
 #include "nullnexus.hpp"
@@ -291,7 +292,10 @@ DEFINE_HOOKED_METHOD(SendNetMsg, bool, INetChannel *this_, INetMessage &msg, boo
         }
     }*/
     if (!strcmp(msg.GetName(), "clc_CmdKeyValues"))
+    {
+        hacks::shared::antiaim::SendNetMessage(msg);
         hacks::shared::catbot::SendNetMsg(msg);
+    }
     if (log_sent && msg.GetType() != 3 && msg.GetType() != 9)
     {
         if (!strcmp(msg.GetName(), "clc_CmdKeyValues"))


### PR DESCRIPTION
This ignores any `.cache/*` files clangd creates, and stops the anti-aim from enabling 2 ticks after the grappling hook has been used, this has been tested and it is working.