### PR TITLE
Fix autobackstab searching for targets even after a valid one was found

### DIFF
--- a/src/hacks/AutoBackstab.cpp
+++ b/src/hacks/AutoBackstab.cpp
@@ -355,6 +355,9 @@ static bool doBacktrackStab(bool legit = false)
     // Get the Best tick
     for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
     {
+        // Found a target, break out
+        if (stab_ent)
+            break;
         CachedEntity *ent = ENTITY(i);
         // Targeting checks
         if (CE_BAD(ent) || !ent->m_bAlivePlayer() || !ent->m_bEnemy() || !player_tools::shouldTarget(ent) || IsPlayerInvulnerable(ent))


### PR DESCRIPTION
Literally just the title. Break out of the autobackstab loop after finding a valid entity instead of trying to backstab every single one of them.