### PR TITLE
Fix CanHeal() for already healing targets

### DIFF
--- a/src/hacks/AutoHeal.cpp
+++ b/src/hacks/AutoHeal.cpp
@@ -473,7 +473,7 @@ void UpdateData()
 bool CanHeal(int idx)
 {
     // Already healing, no need to check
-    if(idx == HandleToIDX(CE_INT(LOCAL_W, netvar.m_hHealingTarget)))
+    if (idx == HandleToIDX(CE_INT(LOCAL_W, netvar.m_hHealingTarget)))
         return true;
     
     CachedEntity *ent = ENTITY(idx);

--- a/src/hacks/AutoHeal.cpp
+++ b/src/hacks/AutoHeal.cpp
@@ -472,6 +472,10 @@ void UpdateData()
 
 bool CanHeal(int idx)
 {
+    // Already healing, no need to check
+    if(idx == HandleToIDX(CE_INT(LOCAL_W, netvar.m_hHealingTarget)))
+        return true;
+    
     CachedEntity *ent = ENTITY(idx);
     if (!ent)
         return false;


### PR DESCRIPTION
I noticed when the current healing target goes out of sight, CanHeal() returns false.
Add a check to return true if the target is already healing.