### PR TITLE
Binary search for ProjectilePrediction()

### DIFF
--- a/data/menu/nullifiedcat/hackinfo.xml
+++ b/data/menu/nullifiedcat/hackinfo.xml
@@ -9,6 +9,8 @@
             <AutoVariable width="fill" target="debug.log-dispatch-user-msg" label="Log dispatched user messages"/>
             <AutoVariable width="fill" target="debug.log-sent-chat" label="Log sent chat"/>
             <AutoVariable width="fill" target="debug.pp-extrapolate" label="PP extrapolate"/>
+            <AutoVariable width="fill" target="debug.pp-bsearch" label="PP binary search"/>
+            <AutoVariable width="fill" target="debug.pp-gravity" label="PP gravity"/>
             <AutoVariable width="fill" target="debug.pp-rocket-time-ping" label="PP rocket time ping"/>
             <AutoVariable width="fill" target="debug.projectiles" label="Debug projectiles"/>
             <AutoVariable width="fill" target="debug.tcm" label="Debug TCM"/>

--- a/src/prediction.cpp
+++ b/src/prediction.cpp
@@ -536,13 +536,17 @@ std::pair<Vector, Vector> ProjectilePrediction(CachedEntity *ent, int hb, float 
 
     if (debug_pp_bsearch)
     {
+        Vector stepvel = velocity;
         float mintime = currenttime, maxtime = currenttime + range * 2;
 
         for (int steps = 0; steps < maxsteps; steps++)
         {
             const float latency = g_IEngine->GetNetChannelInfo()->GetLatency(FLOW_OUTGOING) + cl_interp->GetFloat();
 
+            // Hack as PredictStep() updates velocity
+            stepvel = velocity;
             Vector minloc = PredictStep(origin, velocity, acceleration, &minmax, mintime, strafe_pred ? &*strafe_pred : nullptr);
+            stepvel = velocity;
             Vector maxloc = PredictStep(origin, velocity, acceleration, &minmax, maxtime, strafe_pred ? &*strafe_pred : nullptr);
 
             if (onground)


### PR DESCRIPTION
Two improvements:

* Use binary search for time prediction in ProjectilePrediction(). We get very tight mindelta with same time complexity. (Flag: `debug.pp-bsearch`)
* Account for projectile gravity drop. (Flag: `debug.pp-gravity`)

Both changes are gated by the flags. No-op code change -- should not affect existing configs.