### PR TITLE
Add better Anti-aim options to HvH menu

### DIFF
--- a/data/menu/nullifiedcat/antiaim.xml
+++ b/data/menu/nullifiedcat/antiaim.xml
@@ -47,11 +47,10 @@
 							<Option name="Spin" value="6"/>
 							<Option name="Edge" value="7"/>
 							<Option name="Sideways" value="8"/>
-							<Option name="Jitter" value="9"/>
-							<Option name="Heck" value="10"/>
-							<Option name="Omega" value="11"/>
-							<Option name="Random" value="12"/>
-							<Option name="Random Clamped" value="13"/>
+							<Option name="Heck" value="9"/>
+							<Option name="Omega" value="10"/>
+							<Option name="Random" value="11"/>
+							<Option name="Random Clamped" value="12"/>
 						</Select>
 					</LabeledObject>
 					<LabeledObject width="fill" label="Real Yaw">
@@ -65,11 +64,10 @@
 							<Option name="Spin" value="6"/>
 							<Option name="Edge" value="7"/>
 							<Option name="Sideways" value="8"/>
-							<Option name="Jitter" value="9"/>
-							<Option name="Heck" value="10"/>
-							<Option name="Omega" value="11"/>
-							<Option name="Random" value="12"/>
-							<Option name="Random Clamped" value="13"/>
+							<Option name="Heck" value="9"/>
+							<Option name="Omega" value="10"/>
+							<Option name="Random" value="11"/>
+							<Option name="Random Clamped" value="12"/>
 						</Select>
 					</LabeledObject>
 					<AutoVariable width="fill" target="antiaim.yaw.fake.static" label="Custom Fake" tooltip="Used when 'Fake Yaw' is set to 'Custom'."/>

--- a/data/menu/nullifiedcat/antiaim.xml
+++ b/data/menu/nullifiedcat/antiaim.xml
@@ -9,51 +9,65 @@
             <AutoVariable width="fill" target="misc.fakelag-midair-only" label="Fakelag midair only"/>
             <AutoVariable width="fill" target="antiaim.spin-speed" label="Spin speed" tooltip="Speed for yaw spin." min="-45" max="45" step="0.1"/>
             <AutoVariable width="fill" target="antiaim.roll" label="Roll"/>
-            <LabeledObject width="fill" label="Pitch mode">
-                <Select target="antiaim.pitch.mode">
+            <LabeledObject width="fill" label="Fake Pitch">
+                <Select target="antiaim.pitch.fake">
                     <Option name="Disable" value="0"/>
-                    <Option name="Custom" value="1"/>
-                    <Option name="Jitter" value="2"/>
-                    <Option name="Random" value="3"/>
-                    <Option name="Flip" value="4"/>
-                    <Option name="Fakeflip" value="5"/>
-                    <Option name="Fakeup" value="6"/>
-                    <Option name="Fakedown" value="7"/>
-                    <Option name="Fakecenter" value="8"/>
-                    <Option name="Up" value="9"/>
-                    <Option name="Down" value="10"/>
-                    <Option name="Heck" value="11"/>
+                    <Option name="Up" value="1"/>
+                    <Option name="Down" value="2"/>
+                    <Option name="Inverse" value="3"/>
                 </Select>
             </LabeledObject>
-            <AutoVariable width="fill" target="antiaim.pitch.static" label="Custom pitch" tooltip="Used when 'Pitch mode' is set to 'Custom'."/>
-            <LabeledObject width="fill" label="Yaw mode">
-                <Select target="antiaim.yaw.mode">
+            <LabeledObject width="fill" label="Real Pitch">
+                <Select target="antiaim.pitch.real">
                     <Option name="Disable" value="0"/>
                     <Option name="Custom" value="1"/>
-                    <Option name="Custom offset" value="6"/>
-                    <Option name="Jitter" value="2"/>
-                    <Option name="BigRandom" value="3"/>
-                    <Option name="Random" value="4"/>
-                    <Option name="Spin" value="5"/>
+                    <Option name="Up" value="2"/>
+                    <Option name="Down" value="3"/>
+                    <Option name="Jitter" value="4"/>
+                    <Option name="Random" value="5"/>
+                    <Option name="Flip" value="6"/>
+                    <Option name="Heck" value="7"/>
+                </Select>
+            </LabeledObject>
+            <AutoVariable width="fill" target="antiaim.pitch.static" label="Custom Pitch" tooltip="Used when 'Real Pitch' is set to 'Custom'."/>
+            <LabeledObject width="fill" label="Fake Yaw">
+                <Select target="antiaim.yaw.fake">
+                    <Option name="Disable" value="0"/>
+                    <Option name="Custom" value="1"/>
+                    <Option name="Custom Offset" value="2"/>
+                    <Option name="Left" value="3"/>
+                    <Option name="Right" value="4"/>
+                    <Option name="Back" value="5"/>
+                    <Option name="Spin" value="6"/>
                     <Option name="Edge" value="7"/>
-                    <Option name="Heck" value="8"/>
-                    <Option name="Fake" value="9"/>
-                    <Option name="FakeStatic" value="10"/>
-                    <Option name="FakeJitter" value="11"/>
-                    <Option name="FakeBRandom" value="12"/>
-                    <Option name="FakeRandom" value="13"/>
-                    <Option name="FakeSpin" value="14"/>
-                    <Option name="FakeOffset" value="15"/>
-                    <Option name="FakeEdge" value="16"/>
-                    <Option name="FakeHeck" value="17"/>
-                    <Option name="FakeSideways" value="18"/>
-                    <Option name="FakeLeft" value="19"/>
-                    <Option name="FakeRight" value="20"/>
-                    <Option name="FakeREdge" value="21"/>
-                    <Option name="TestAA" value="22"/>
+                    <Option name="Sideways" value="8"/>
+                    <Option name="Jitter" value="9"/>
+                    <Option name="Heck" value="10"/>
+                    <Option name="Omega" value="11"/>
+                    <Option name="Random" value="12"/>
+                    <Option name="Random Clamped" value="13"/>
                 </Select>
             </LabeledObject>
-            <AutoVariable width="fill" target="antiaim.yaw.static" label="Custom yaw" tooltip="Used when 'Yaw mode' is set to 'Custom'."/>
+            <AutoVariable width="fill" target="antiaim.yaw.fake.static" label="Custom Fake Yaw" tooltip="Used when 'Fake Yaw' is set to 'Custom'."/>
+            <LabeledObject width="fill" label="Real Yaw">
+                <Select target="antiaim.yaw.real">
+                    <Option name="Disable" value="0"/>
+                    <Option name="Custom" value="1"/>
+                    <Option name="Custom Offset" value="2"/>
+                    <Option name="Left" value="3"/>
+                    <Option name="Right" value="4"/>
+                    <Option name="Back" value="5"/>
+                    <Option name="Spin" value="6"/>
+                    <Option name="Edge" value="7"/>
+                    <Option name="Sideways" value="8"/>
+                    <Option name="Jitter" value="9"/>
+                    <Option name="Heck" value="10"/>
+                    <Option name="Omega" value="11"/>
+                    <Option name="Random" value="12"/>
+                    <Option name="Random Clamped" value="13"/>
+                </Select>
+            </LabeledObject>
+            <AutoVariable width="fill" target="antiaim.yaw.real.static" label="Custom Real Yaw" tooltip="Used when 'Real Yaw' is set to 'Custom'."/>
         </List>
     </Box>
     <Box padding="12 6 6 6" width="content" height="content" name="Resolver" x="170">

--- a/data/menu/nullifiedcat/antiaim.xml
+++ b/data/menu/nullifiedcat/antiaim.xml
@@ -9,65 +9,73 @@
             <AutoVariable width="fill" target="misc.fakelag-midair-only" label="Fakelag midair only"/>
             <AutoVariable width="fill" target="antiaim.spin-speed" label="Spin speed" tooltip="Speed for yaw spin." min="-45" max="45" step="0.1"/>
             <AutoVariable width="fill" target="antiaim.roll" label="Roll"/>
-            <LabeledObject width="fill" label="Fake Pitch">
-                <Select target="antiaim.pitch.fake">
-                    <Option name="Disable" value="0"/>
-                    <Option name="Up" value="1"/>
-                    <Option name="Down" value="2"/>
-                    <Option name="Inverse" value="3"/>
-                </Select>
-            </LabeledObject>
-            <LabeledObject width="fill" label="Real Pitch">
-                <Select target="antiaim.pitch.real">
-                    <Option name="Disable" value="0"/>
-                    <Option name="Custom" value="1"/>
-                    <Option name="Up" value="2"/>
-                    <Option name="Down" value="3"/>
-                    <Option name="Jitter" value="4"/>
-                    <Option name="Random" value="5"/>
-                    <Option name="Flip" value="6"/>
-                    <Option name="Heck" value="7"/>
-                </Select>
-            </LabeledObject>
-            <AutoVariable width="fill" target="antiaim.pitch.static" label="Custom Pitch" tooltip="Used when 'Real Pitch' is set to 'Custom'."/>
-            <LabeledObject width="fill" label="Fake Yaw">
-                <Select target="antiaim.yaw.fake">
-                    <Option name="Disable" value="0"/>
-                    <Option name="Custom" value="1"/>
-                    <Option name="Custom Offset" value="2"/>
-                    <Option name="Left" value="3"/>
-                    <Option name="Right" value="4"/>
-                    <Option name="Back" value="5"/>
-                    <Option name="Spin" value="6"/>
-                    <Option name="Edge" value="7"/>
-                    <Option name="Sideways" value="8"/>
-                    <Option name="Jitter" value="9"/>
-                    <Option name="Heck" value="10"/>
-                    <Option name="Omega" value="11"/>
-                    <Option name="Random" value="12"/>
-                    <Option name="Random Clamped" value="13"/>
-                </Select>
-            </LabeledObject>
-            <AutoVariable width="fill" target="antiaim.yaw.fake.static" label="Custom Fake Yaw" tooltip="Used when 'Fake Yaw' is set to 'Custom'."/>
-            <LabeledObject width="fill" label="Real Yaw">
-                <Select target="antiaim.yaw.real">
-                    <Option name="Disable" value="0"/>
-                    <Option name="Custom" value="1"/>
-                    <Option name="Custom Offset" value="2"/>
-                    <Option name="Left" value="3"/>
-                    <Option name="Right" value="4"/>
-                    <Option name="Back" value="5"/>
-                    <Option name="Spin" value="6"/>
-                    <Option name="Edge" value="7"/>
-                    <Option name="Sideways" value="8"/>
-                    <Option name="Jitter" value="9"/>
-                    <Option name="Heck" value="10"/>
-                    <Option name="Omega" value="11"/>
-                    <Option name="Random" value="12"/>
-                    <Option name="Random Clamped" value="13"/>
-                </Select>
-            </LabeledObject>
-            <AutoVariable width="fill" target="antiaim.yaw.real.static" label="Custom Real Yaw" tooltip="Used when 'Real Yaw' is set to 'Custom'."/>
+            <Box padding="12 6 6 6" width="content" height="content" name="Pitch" y="90">
+				<List width="138">
+					<LabeledObject width="fill" label="Fake Pitch">
+						<Select target="antiaim.pitch.fake">
+							<Option name="Disable" value="0"/>
+							<Option name="Up" value="1"/>
+							<Option name="Down" value="2"/>
+							<Option name="Inverse" value="3"/>
+						</Select>
+					</LabeledObject>
+					<LabeledObject width="fill" label="Real Pitch">
+						<Select target="antiaim.pitch.real">
+							<Option name="Disable" value="0"/>
+							<Option name="Custom" value="1"/>
+							<Option name="Up" value="2"/>
+							<Option name="Down" value="3"/>
+							<Option name="Jitter" value="4"/>
+							<Option name="Random" value="5"/>
+							<Option name="Flip" value="6"/>
+							<Option name="Heck" value="7"/>
+						</Select>
+					</LabeledObject>
+					<AutoVariable width="fill" target="antiaim.pitch.static" label="Custom" tooltip="Used when 'Real Pitch' is set to 'Custom'."/>
+				</List>
+			</Box>
+			<Box padding="12 6 6 6" width="content" height="content" name="Yaw" y="120">
+				<List width="138">
+					<LabeledObject width="fill" label="Fake Yaw">
+						<Select target="antiaim.yaw.fake">
+							<Option name="Disable" value="0"/>
+							<Option name="Custom" value="1"/>
+							<Option name="Custom Offset" value="2"/>
+							<Option name="Left" value="3"/>
+							<Option name="Right" value="4"/>
+							<Option name="Back" value="5"/>
+							<Option name="Spin" value="6"/>
+							<Option name="Edge" value="7"/>
+							<Option name="Sideways" value="8"/>
+							<Option name="Jitter" value="9"/>
+							<Option name="Heck" value="10"/>
+							<Option name="Omega" value="11"/>
+							<Option name="Random" value="12"/>
+							<Option name="Random Clamped" value="13"/>
+						</Select>
+					</LabeledObject>
+					<LabeledObject width="fill" label="Real Yaw">
+						<Select target="antiaim.yaw.real">
+							<Option name="Disable" value="0"/>
+							<Option name="Custom" value="1"/>
+							<Option name="Custom Offset" value="2"/>
+							<Option name="Left" value="3"/>
+							<Option name="Right" value="4"/>
+							<Option name="Back" value="5"/>
+							<Option name="Spin" value="6"/>
+							<Option name="Edge" value="7"/>
+							<Option name="Sideways" value="8"/>
+							<Option name="Jitter" value="9"/>
+							<Option name="Heck" value="10"/>
+							<Option name="Omega" value="11"/>
+							<Option name="Random" value="12"/>
+							<Option name="Random Clamped" value="13"/>
+						</Select>
+					</LabeledObject>
+					<AutoVariable width="fill" target="antiaim.yaw.fake.static" label="Custom Fake" tooltip="Used when 'Fake Yaw' is set to 'Custom'."/>
+					<AutoVariable width="fill" target="antiaim.yaw.real.static" label="Custom Real" tooltip="Used when 'Real Yaw' is set to 'Custom'."/>
+				</List>
+			</Box>
         </List>
     </Box>
     <Box padding="12 6 6 6" width="content" height="content" name="Resolver" x="170">

--- a/src/hacks/AntiAim.cpp
+++ b/src/hacks/AntiAim.cpp
@@ -334,7 +334,7 @@ bool findEdge(float edgeOrigYaw)
     {
         edgeToEdgeOn = 1;
         // Correction for pitches to keep the head behind walls
-        if (((int) pitch_mode == 7) || ((int) pitch_mode == 2) || ((int) pitch_mode == 8))
+        if (((int) pitch_real == 7) || ((int) pitch_real == 9) || ((int) pitch_real == 10))
             edgeToEdgeOn = 2;
         return true;
     }
@@ -342,7 +342,7 @@ bool findEdge(float edgeOrigYaw)
     {
         edgeToEdgeOn = 2;
         // Same as above
-        if (((int) pitch_mode == 7) || ((int) pitch_mode == 2) || ((int) pitch_mode == 8))
+        if (((int) pitch_real == 7) || ((int) pitch_real == 9) || ((int) pitch_real == 10))
             edgeToEdgeOn = 1;
         return true;
     }
@@ -411,7 +411,7 @@ void ProcessUserCmd(CUserCmd *cmd)
     static bool swap          = true;
 	
 	// Reset the ticks and swap for some reason...
-    if (ticksUntilSwap > 0 && *yaw_mode != 8)
+    if (ticksUntilSwap > 0 && (*yaw_fake != 8 || *yaw_real != 8))
     {
         swap           = true;
         ticksUntilSwap = 0;
@@ -438,10 +438,10 @@ void ProcessUserCmd(CUserCmd *cmd)
 			break;
 		case 6: // Spin
 			cur_yaw_fake += (float) spin;
-			while (cur_yaw_fake > 180)
-				cur_yaw_fake += -360;
-			while (cur_yaw_fake < -180)
-				cur_yaw_fake += 360;
+			while (cur_yaw_fake > 180.0f)
+				cur_yaw_fake += -360.0f;
+			while (cur_yaw_fake < -180.0f)
+				cur_yaw_fake += 360.0f;
 			y = cur_yaw_fake;
 			break;
 		case 7: // Edge
@@ -481,74 +481,74 @@ void ProcessUserCmd(CUserCmd *cmd)
 		default:
 			break;
 		}
-    
-    switch ((int) yaw_real)
-    {
-    case 1: // Custom
-        y = (float) yaw_real_static;
-        break;
-    case 2: // Custom Offset
-        y += (float) yaw_real_static;
-        break;
-    case 3: // Left
-        y -= 90.0f;
-        break;
-    case 4: // Right
-        y += 90.0f;
-        break;
-    case 5: // Back
-        y += 180.0f;
-        break;
-    case 6: // Spin
-        cur_yaw_real += (float) spin;
-        while (cur_yaw_real > 180)
-            cur_yaw_real += -360;
-        while (cur_yaw_real < -180)
-            cur_yaw_real += 360;
-        y = cur_yaw_real;
-        break;
-    case 7: // Edge
-        // Attempt to find an edge and if found, rotate around it
-        if (findEdge(y))
-            y = useEdge(y);
-        break;
-    case 8: // Sideways
-		if (ticksUntilSwap--)
-        {
-            ticksUntilSwap = UniformRandomInt(*yaw_sideways_min, *yaw_sideways_max);
-            swap           = !swap;
-        }
-        y += swap ? 90.0f : -90.0f;
-        break;
-    case 9: // Jitter
-        if (flip)
-            y += 90;
-        else
-            y -= 90;
-        break;
-    case 10: // Heck
-        FuckYaw(y);
-        clamp = false;
-        break;
-    case 11: // Omega
-        y = randyaw - 180.0f + RandFloatRange(-40.0f, 40.0f);
-        break;
-    case 12: // Random
-        y     = RandFloatRange(-65536.0f, 65536.0f);
-        clamp = false;
-        break;
-    case 13: // Random Clamped
-        y = RandFloatRange(-180.0f, 180.0f);
-        break;
-    default:
-        break;
-    }
+	else
+		switch ((int) yaw_real)
+		{
+		case 1: // Custom
+			y = (float) yaw_real_static;
+			break;
+		case 2: // Custom Offset
+			y += (float) yaw_real_static;
+			break;
+		case 3: // Left
+			y -= 90.0f;
+			break;
+		case 4: // Right
+			y += 90.0f;
+			break;
+		case 5: // Back
+			y += 180.0f;
+			break;
+		case 6: // Spin
+			cur_yaw_real += (float) spin;
+			while (cur_yaw_real > 180.0f)
+				cur_yaw_real += -360.0f;
+			while (cur_yaw_real < -180.0f)
+				cur_yaw_real += 360.0f;
+			y = cur_yaw_real;
+			break;
+		case 7: // Edge
+			// Attempt to find an edge and if found, rotate around it
+			if (findEdge(y))
+				y = useEdge(y);
+			break;
+		case 8: // Sideways
+			if (ticksUntilSwap--)
+			{
+				ticksUntilSwap = UniformRandomInt(*yaw_sideways_min, *yaw_sideways_max);
+				swap           = !swap;
+			}
+			y += swap ? 90.0f : -90.0f;
+			break;
+		case 9: // Jitter
+			if (flip)
+				y += 90;
+			else
+				y -= 90;
+			break;
+		case 10: // Heck
+			FuckYaw(y);
+			clamp = false;
+			break;
+		case 11: // Omega
+			y = randyaw - 180.0f + RandFloatRange(-40.0f, 40.0f);
+			break;
+		case 12: // Random
+			y     = RandFloatRange(-65536.0f, 65536.0f);
+			clamp = false;
+			break;
+		case 13: // Random Clamped
+			y = RandFloatRange(-180.0f, 180.0f);
+			break;
+		default:
+			break;
+		}
     
     // Pitch logic
     switch (int(pitch_real))
     {
     case 1: // Custom
-        p = float(pitch);
+        p = float(pitch_static);
         break;
     case 2: // Up
         p = -89.0f;
@@ -583,12 +583,14 @@ void ProcessUserCmd(CUserCmd *cmd)
         p += 360.0f;
         break;
     case 3: // Inverse
-        p = -p;
+		if (p <= -89.0f)
+			p += 360.0f;
+		else if (p >= 89.0f)
+			p -= 360.0f;
         break;
     }
     
-    if (g_pLocalPlayer->isFakeAngleCM)
-        flip = !flip;
+    flip = !flip;
     if (clamp)
         fClampAngle(cmd->viewangles);
     if (roll)
@@ -609,5 +611,5 @@ bool isEnabled()
     return *enable;
 }
 
-static InitRoutine fakelag_check([]() { yaw_mode.installChangeCallback([](settings::VariableBase<int> &, int after) { force_fakelag = after >= 9 ? true : false; }); });
+static InitRoutine fakelag_check([]() { yaw_fake.installChangeCallback([](settings::VariableBase<int> &, int after) { force_fakelag = after > 0 ? true : false; }); });
 } // namespace hacks::shared::antiaim


### PR DESCRIPTION
This pull request addresses a multitude of issues and complaints related to the functionality of Anti-aim in cathook. Previously you were not able to independently set fake and real angles for both pitch and yaw angles - this has now been solved with the creation of `antiaim.pitch.fake`, `antiaim.pitch.real`, `antiaim.yaw.fake` and `antiaim.yaw.real` with the additional static/custom values that can be set to each angle. 

![image](https://user-images.githubusercontent.com/12992355/123500092-7ae7e680-d609-11eb-91ba-25f7e0348f91.png)

I've been unable to test if fake yaw angles are working due to them not being visible in local servers (if that is what's happening), so I ask if anyone else could test them and determine that they're good to go for merging. I also apologize if the tab formatting looks different in GitHub, both Featherpad and Geany do that on my end.
