### PR TITLE
Switch back to engine prediction and make it work properly

### DIFF
--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -54,7 +54,7 @@ static settings::Float proj_start_vel{ "aimbot.projectile.initial-velocity", "0"
 static settings::Float sticky_autoshoot{ "aimbot.projectile.sticky-autoshoot", "0.5" };
 
 static settings::Boolean aimbot_debug{ "aimbot.debug", "0" };
-static settings::Boolean engine_projpred{ "aimbot.debug.engine-pp", "0" };
+static settings::Boolean engine_projpred{ "aimbot.debug.engine-pp", "1" };
 
 static settings::Boolean auto_spin_up{ "aimbot.auto.spin-up", "0" };
 static settings::Boolean minigun_tapfire{ "aimbot.auto.tapfire", "false" };
@@ -1267,11 +1267,11 @@ int BestHitbox(CachedEntity *target)
         {
             int ci    = g_pLocalPlayer->weapon()->m_iClassID();
             preferred = hitbox_t::spine_3;
-            
+
             // Sniper rifle
             if (g_pLocalPlayer->holding_sniper_rifle)
                 headonly = CanHeadshot();
-            
+
             // Hunstman
             else if (ci == CL_CLASS(CTFCompoundBow))
             {
@@ -1283,7 +1283,7 @@ int BestHitbox(CachedEntity *target)
                 else
                     preferred = hitbox_t::head;
             }
-            
+
             // Ambassador
             else if (IsAmbassador(g_pLocalPlayer->weapon()))
             {
@@ -1294,17 +1294,13 @@ int BestHitbox(CachedEntity *target)
                 if (target->m_iHealth() <= 18 || IsPlayerCritBoosted(g_pLocalPlayer->entity) || target->m_flDistance() > 1200)
                     headonly = false;
             }
-            
+
             // Rockets and stickies should aim at the foot if the target is on the ground
-            else if (ci == CL_CLASS(CTFPipebombLauncher) || 
-				ci == CL_CLASS(CTFRocketLauncher) || 
-				ci == CL_CLASS(CTFParticleCannon) || 
-				ci == CL_CLASS(CTFRocketLauncher_AirStrike) || 
-				ci == CL_CLASS(CTFRocketLauncher_Mortar) ||
-				ci == CL_CLASS(CTFRocketLauncher_DirectHit))
+            else if (ci == CL_CLASS(CTFPipebombLauncher) || ci == CL_CLASS(CTFRocketLauncher) || ci == CL_CLASS(CTFParticleCannon) || ci == CL_CLASS(CTFRocketLauncher_AirStrike) || ci == CL_CLASS(CTFRocketLauncher_Mortar) || ci == CL_CLASS(CTFRocketLauncher_DirectHit))
             {
-				bool ground = CE_INT(target, netvar.iFlags) & (1 << 0);
-				if (ground) preferred = hitbox_t::foot_L;
+                bool ground = CE_INT(target, netvar.iFlags) & (1 << 0);
+                if (ground)
+                    preferred = hitbox_t::foot_L;
             }
 
             // Bodyshot handling
@@ -1312,7 +1308,7 @@ int BestHitbox(CachedEntity *target)
             {
                 float cdmg = CE_FLOAT(LOCAL_W, netvar.flChargedDamage);
                 float bdmg = 50;
-                 // Vaccinator damage correction, protects against 20% of damage
+                // Vaccinator damage correction, protects against 20% of damage
                 if (CarryingHeatmaker())
                 {
                     bdmg = (bdmg * .80) - 1;
@@ -1323,7 +1319,6 @@ int BestHitbox(CachedEntity *target)
                 {
                     bdmg = (bdmg * .25) - 1;
                     cdmg = (cdmg * .25) - 1;
-                    
                 }
                 // Passive bullet resist protects against 10% of damage
                 else if (HasCondition<TFCond_SmallBulletResist>(target))
@@ -1352,9 +1347,8 @@ int BestHitbox(CachedEntity *target)
             }
         }
         // In counter-strike source, headshots are what we want
-        else IF_GAME(IsCSS())
-            headonly = true;
-        
+        else IF_GAME(IsCSS()) headonly = true;
+
         // Head only
         if (headonly)
         {

--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -54,7 +54,7 @@ static settings::Float proj_start_vel{ "aimbot.projectile.initial-velocity", "0"
 static settings::Float sticky_autoshoot{ "aimbot.projectile.sticky-autoshoot", "0.5" };
 
 static settings::Boolean aimbot_debug{ "aimbot.debug", "0" };
-static settings::Boolean engine_projpred{ "aimbot.debug.engine-pp", "1" };
+settings::Boolean engine_projpred{ "aimbot.debug.engine-pp", "1" };
 
 static settings::Boolean auto_spin_up{ "aimbot.auto.spin-up", "0" };
 static settings::Boolean minigun_tapfire{ "aimbot.auto.tapfire", "false" };

--- a/src/prediction.cpp
+++ b/src/prediction.cpp
@@ -9,6 +9,11 @@
 #include <settings/Bool.hpp>
 #include <boost/circular_buffer.hpp>
 
+namespace hacks::shared::aimbot
+{
+extern settings::Boolean engine_projpred;
+}
+
 static settings::Boolean debug_pp_extrapolate{ "debug.pp-extrapolate", "false" };
 static settings::Boolean debug_pp_draw{ "debug.pp-draw", "false" };
 static settings::Boolean debug_pp_draw_engine{ "debug.pp-draw.engine", "false" };
@@ -720,6 +725,9 @@ static InitRoutine init(
             EC::CreateMove,
             []()
             {
+                // Don't run if we don't use it
+                if (!hacks::shared::aimbot::engine_projpred && !debug_pp_draw)
+                    return;
                 for (int i = 1; i < g_GlobalVars->maxClients; i++)
                 {
                     auto ent     = ENTITY(i);

--- a/src/velocity.cpp
+++ b/src/velocity.cpp
@@ -16,11 +16,6 @@ EstimateAbsVelocity_t EstimateAbsVelocity{};
 
 void Init()
 {
-    EstimateAbsVelocity = (void (*)(IClientEntity *, Vector &)) gSignatures.GetClientSignature("55 89 E5 56 53 83 EC 20 8B 5D 08 8B 75 0C E8 ? ? ? ? 39 D8 74 79 "
-                                                                                               "0F B6 05 ? ? ? ? 81 C3 B8 02 00 00 C6 05 ? ? ? ? 01 F3 0F 10 05 ? "
-                                                                                               "? ? ? F3 0F 11 45 F0 88 45 EC A1 ? ? ? ? 89 45 E8 8D 45 E8 A3 ? ? "
-                                                                                               "? ? A1 ? ? ? ? F3 0F 10 40 0C 89 74 24 04 89 1C 24 F3 0F 11 44 24 "
-                                                                                               "08 E8 ? ? ? ? 0F B6 45 EC F3 0F 10 45 F0 F3 0F 11 05 ? ? ? ? A2 ? "
-                                                                                               "? ? ? 8B 45 E8 A3 ? ? ? ? 83 C4 20 5B 5E 5D C3");
+    EstimateAbsVelocity = (void (*)(IClientEntity *, Vector &)) gSignatures.GetClientSignature("55 89 E5 56 53 83 EC 20 8B 5D ? 8B 75 ? E8 ? ? ? ? 39 D8");
 }
 } // namespace velocity


### PR DESCRIPTION
This will probably need some testing first.

We use engine prediction to get properly accurate simulations and avoid the hassle of replicating prediction ourselves.

To use Strafe prediction, the user will have to switch back to "normal" prediction instead.