### PR TITLE
Fix crashes with radar when object team is -1

### DIFF
--- a/src/hacks/Radar.cpp
+++ b/src/hacks/Radar.cpp
@@ -244,7 +244,7 @@ void Draw()
         ent = ENTITY(i);
         if (CE_INVALID(ent))
             continue;
-        if (ent->m_iTeam() != -1)
+        if (ent->m_iTeam() == 0)
             continue;
         if (!ent->m_bAlivePlayer())
             continue;

--- a/src/hacks/Radar.cpp
+++ b/src/hacks/Radar.cpp
@@ -244,6 +244,8 @@ void Draw()
         ent = ENTITY(i);
         if (CE_INVALID(ent))
             continue;
+        if (ent->m_iTeam() != -1)
+            continue;
         if (!ent->m_bAlivePlayer())
             continue;
         if (i == g_IEngine->GetLocalPlayer())


### PR DESCRIPTION
only really affects us if we spawn an object via console