### PR TITLE
Quit tf2 without causing a crash

### DIFF
--- a/src/hacks/AutoJoin.cpp
+++ b/src/hacks/AutoJoin.cpp
@@ -105,7 +105,7 @@ void updateSearch()
 #if not ENABLE_VISUALS
     if (queue_time.test_and_set(1200000))
     {
-        *(int *) nullptr = 0;
+        g_IEngine->ClientCmd_Unrestricted("quit"); //lol
     }
 #endif
 }


### PR DESCRIPTION
if we do it like this no more crash logs from autojoin