### PR TITLE
Fix projectile aimbot aiming at wrong places

### DIFF
--- a/src/hacks/Aimbot.cpp
+++ b/src/hacks/Aimbot.cpp
@@ -1437,7 +1437,7 @@ int BestHitbox(CachedEntity *target)
         if (target->hitboxes.VisibilityCheck(preferred))
             return preferred;
         // Else attempt to find any hitbox at all
-        for (int i = projectile_mode ? 1 : 0; i < target->hitboxes.GetNumHitboxes() && i < 6; i++)
+        for (int i = 6; i > projectile_mode ? 1 : 0 && i < 6; i--)
             if (target->hitboxes.VisibilityCheck(i))
                 return i;
     }

--- a/src/prediction.cpp
+++ b/src/prediction.cpp
@@ -546,7 +546,7 @@ std::pair<Vector, Vector> ProjectilePrediction_Engine(CachedEntity *ent, int hb,
         float rockettime = g_pLocalPlayer->v_Eye.DistTo(current) / speed;
         // Compensate for ping
         rockettime += g_IEngine->GetNetChannelInfo()->GetLatency(FLOW_OUTGOING) + cl_interp->GetFloat();
-        float timedelta = fabs(currenttime - rockettime);
+        float timedelta = fabs(currenttime > rockettime ? currenttime - rockettime : rockettime - currenttime);
         if (timedelta < mindelta)
         {
             besttime = currenttime;
@@ -650,7 +650,7 @@ std::pair<Vector, Vector> ProjectilePrediction(CachedEntity *ent, int hb, float 
         float rockettime = g_pLocalPlayer->v_Eye.DistTo(current) / speed;
         // Compensate for ping
         rockettime += g_IEngine->GetNetChannelInfo()->GetLatency(FLOW_OUTGOING) + cl_interp->GetFloat();
-        if (fabs(currenttime - rockettime) < mindelta)
+        if (fabs(currenttime > rockettime ? currenttime - rockettime : rockettime - currenttime) < mindelta)
         {
             besttime = currenttime;
             bestpos  = current;

--- a/src/prediction.cpp
+++ b/src/prediction.cpp
@@ -546,7 +546,7 @@ std::pair<Vector, Vector> ProjectilePrediction_Engine(CachedEntity *ent, int hb,
         float rockettime = g_pLocalPlayer->v_Eye.DistTo(current) / speed;
         // Compensate for ping
         rockettime += g_IEngine->GetNetChannelInfo()->GetLatency(FLOW_OUTGOING) + cl_interp->GetFloat();
-        float timedelta = fabs(rockettime - currenttime);
+        float timedelta = fabs(currenttime - rockettime);
         if (timedelta < mindelta)
         {
             besttime = currenttime;
@@ -650,7 +650,7 @@ std::pair<Vector, Vector> ProjectilePrediction(CachedEntity *ent, int hb, float 
         float rockettime = g_pLocalPlayer->v_Eye.DistTo(current) / speed;
         // Compensate for ping
         rockettime += g_IEngine->GetNetChannelInfo()->GetLatency(FLOW_OUTGOING) + cl_interp->GetFloat();
-        if (fabs(rockettime - currenttime) < mindelta)
+        if (fabs(currenttime - rockettime) < mindelta)
         {
             besttime = currenttime;
             bestpos  = current;


### PR DESCRIPTION
After sitting down and taking some time to figure out how does the step prediction figure out the best target position, I realized that the method of calculating delta time, responsible for setting the new best position, could be wrong in specific scenarios when the target is moving away from the origin. Inverting it would fix the majority of those cases, however very slight edge cases would require the old ordering, so the higher value out of both variables is now the one being subtracted.

Another correction done was reordering the Auto hitbox scan for projectile weapons - sometimes the preferred hitbox would not be available and the cheat would scan the first available hitbox from top to bottom. This has now changed from bottom to top, since there is a larger chance of hitting the target with lower hitboxes after taking gravity into consideration. 