### PR TITLE
Add more ways for bots to get health and ammo

### DIFF
--- a/src/hacks/NavBot.cpp
+++ b/src/hacks/NavBot.cpp
@@ -172,7 +172,7 @@ bool getHealth(bool low_priority = false)
             if (!repath_timer.test_and_set(2000))
                 return true;
         }
-        auto healthpacks = getEntities({ ITEM_HEALTH_SMALL, ITEM_HEALTH_MEDIUM, ITEM_HEALTH_LARGE });
+        auto healthpacks = getEntities({ ITEM_HEALTH_SMALL, ITEM_HEALTH_MEDIUM, ITEM_HEALTH_LARGE, EDIBLE_SMALL, EDIBLE_MEDIUM, RESUPPLY_LOCKER });
         auto dispensers  = getDispensers();
 
         auto total_ents = healthpacks;
@@ -213,7 +213,7 @@ bool getAmmo(bool force = false)
         }
         else
             was_force = false;
-        auto ammopacks  = getEntities({ ITEM_AMMO_SMALL, ITEM_AMMO_MEDIUM, ITEM_AMMO_LARGE });
+        auto ammopacks  = getEntities({ ITEM_AMMO_SMALL, ITEM_AMMO_MEDIUM, ITEM_AMMO_LARGE, RESUPPLY_LOCKER });
         auto dispensers = getDispensers();
 
         auto total_ents = ammopacks;

--- a/src/itemtypes.cpp
+++ b/src/itemtypes.cpp
@@ -32,6 +32,10 @@ ItemManager::ItemManager() : mapper()
     RegisterModelMapping("models/workshop/weapons/c_models/c_buffalo_steak/plate_buffalo_steak.mdl", EDIBLE_SMALL);
     RegisterModelMapping("models/workshop/weapons/c_models/c_chocolate/plate_chocolate.mdl", EDIBLE_SMALL);
     RegisterModelMapping("models/items/banana/plate_banana.mdl", EDIBLE_SMALL);
+    
+    // lockers
+    RegisterModelMapping("models/props_gameplay/resupply_locker.mdl", RESUPPLY_LOCKER);
+    RegisterModelMapping("models/props_medieval/medieval_resupply.mdl", RESUPPLY_LOCKER);
 
     // == AMMOPACKS
     // Normal


### PR DESCRIPTION
Resupply lockers could cause bots to try and go in enemy spawns but they do that anyways.