### PR TITLE
Projectile Dodging, Optimizations, ESP Fixes/Refactor

### DIFF
--- a/data/menu/nullifiedcat/warp.xml
+++ b/data/menu/nullifiedcat/warp.xml
@@ -16,6 +16,7 @@
             <AutoVariable width="fill" target="warp.charge-passively.jump" label="Charge in jump" tooltip="Charge passively in jump, This will make you fall slower."/>
             <AutoVariable width="fill" target="warp.charge-passively.no-inputs" label="Charge when keys released" tooltip="Charge passively before full stop after releasing movement keys."/>
             <AutoVariable width="fill" target="warp.movement-ratio" label="Movement ratio" tooltip="Every nth movement tick is passively converted to warp."/>
+            <AutoVariable width="fill" target="warp.dodge_proj" label="Dodge projectiles" tooltip="Dodges enemy projectiles using warp."/>
             <AutoVariable width="fill" target="warp.demoknight" label="Demoknight mode" tooltip="This will make you do a swing charge with warp (attack, charge, warp)."/>
             <AutoVariable width="fill" target="warp.peek" label="Peek mode" tooltip="This will teleport you for a tick and then teleport you back."/>
             <AutoVariable width="fill" target="warp.on-hit" label="Warp when hit" tooltip="Warp whenever someone melees you or shoots you with hitscan."/>

--- a/include/entitycache.hpp
+++ b/include/entitycache.hpp
@@ -224,7 +224,7 @@ extern u_int16_t max;
 extern u_int16_t previous_max;
 extern std::vector<CachedEntity *> valid_ents;
 extern std::unordered_map<u_int16_t, CachedEntity> array;
-extern std::map<Vector, CachedEntity *> proj_map;
+extern std::vector<std::tuple<Vector,CachedEntity*>> proj_map;
 extern std::vector<CachedEntity *> skip_these;
 extern std::vector<CachedEntity*> player_cache;
 inline CachedEntity *Get(u_int16_t idx)

--- a/include/entitycache.hpp
+++ b/include/entitycache.hpp
@@ -67,7 +67,7 @@ class CachedEntity
 public:
     typedef CachedEntity ThisClass;
     CachedEntity();
-    CachedEntity(int idx);
+    CachedEntity(u_int16_t idx);
     ~CachedEntity();
 
     __attribute__((hot)) void Update();
@@ -220,8 +220,8 @@ namespace entity_cache
 {
 
 // b1g fat array in
-extern int max;
-extern int previous_max;
+extern u_int16_t max;
+extern u_int16_t previous_max;
 extern std::vector<CachedEntity *> valid_ents;
 extern std::unordered_map<u_int16_t, CachedEntity> array;
 extern std::map<Vector, CachedEntity *> proj_map;

--- a/include/entitycache.hpp
+++ b/include/entitycache.hpp
@@ -59,7 +59,7 @@ constexpr int MAX_STRINGS = 16;
 #define IDX_BAD(idx) !IDX_GOOD(idx)
 
 #define HIGHEST_ENTITY (entity_cache::max)
-#define ENTITY(idx) (&entity_cache::Get(idx))
+#define ENTITY(idx) (entity_cache::Get(idx))
 
 bool IsProjectileACrit(CachedEntity *ent);
 class CachedEntity
@@ -67,6 +67,7 @@ class CachedEntity
 public:
     typedef CachedEntity ThisClass;
     CachedEntity();
+    CachedEntity(int idx);
     ~CachedEntity();
 
     __attribute__((hot)) void Update();
@@ -99,7 +100,7 @@ public:
 
     int m_iClassID()
     {
-        if (RAW_ENT(this))
+        if (this && RAW_ENT(this))
             if (RAW_ENT(this)->GetClientClass())
                 if (RAW_ENT(this)->GetClientClass()->m_ClassID)
                     return RAW_ENT(this)->GetClientClass()->m_ClassID;
@@ -202,7 +203,7 @@ public:
     Vector m_vecVelocity{ 0 };
     Vector m_vecAcceleration{ 0 };
     float m_fLastUpdate{ 0.0f };
-    hitbox_cache::EntityHitboxCache &hitboxes;
+    hitbox_cache::EntityHitboxCache hitboxes;
     player_info_s player_info{};
     Averager<float> velocity_averager{ 8 };
     bool was_dormant()
@@ -219,16 +220,24 @@ namespace entity_cache
 {
 
 // b1g fat array in
+extern int max;
+extern int previous_max;
 extern std::vector<CachedEntity *> valid_ents;
-extern CachedEntity array[MAX_ENTITIES];
-inline CachedEntity &Get(int idx)
+extern std::unordered_map<u_int16_t, CachedEntity> array;
+extern std::map<Vector, CachedEntity *> proj_map;
+extern std::vector<CachedEntity *> skip_these;
+extern std::vector<CachedEntity*> player_cache;
+inline CachedEntity *Get(u_int16_t idx)
 {
-    if (idx < 0 || idx >= 2048)
-        throw std::out_of_range("Entity index out of range!");
-    return array[idx];
+    auto iterator = array.find(idx);
+    if (iterator == array.end())
+        return nullptr;
+    else
+        return &iterator->second;
 }
+void dodgeProj(CachedEntity *proj_ptr);
 void Update();
 void Invalidate();
 void Shutdown();
-extern int max;
+
 } // namespace entity_cache

--- a/include/entitycache.hpp
+++ b/include/entitycache.hpp
@@ -227,7 +227,7 @@ extern std::unordered_map<u_int16_t, CachedEntity> array;
 extern std::vector<std::tuple<Vector,CachedEntity*>> proj_map;
 extern std::vector<CachedEntity *> skip_these;
 extern std::vector<CachedEntity*> player_cache;
-inline CachedEntity *Get(u_int16_t idx)
+inline CachedEntity *Get(const u_int16_t &idx)
 {
     auto iterator = array.find(idx);
     if (iterator == array.end())

--- a/include/entitycache.hpp
+++ b/include/entitycache.hpp
@@ -24,7 +24,6 @@
 #include "client_class.h"
 #include "Constants.hpp"
 #include <optional>
-
 struct matrix3x4_t;
 
 class IClientEntity;
@@ -224,8 +223,7 @@ extern u_int16_t max;
 extern u_int16_t previous_max;
 extern std::vector<CachedEntity *> valid_ents;
 extern std::unordered_map<u_int16_t, CachedEntity> array;
-extern std::vector<std::tuple<Vector,CachedEntity*>> proj_map;
-extern std::vector<CachedEntity *> skip_these;
+extern std::vector<std::tuple<Vector, CachedEntity *>> proj_map;
 extern std::vector<CachedEntity*> player_cache;
 inline CachedEntity *Get(const u_int16_t &idx)
 {

--- a/include/entityhitboxcache.hpp
+++ b/include/entityhitboxcache.hpp
@@ -31,7 +31,9 @@ struct CachedHitbox
 class EntityHitboxCache
 {
 public:
-    EntityHitboxCache();
+ 
+    EntityHitboxCache() = default;
+    EntityHitboxCache(int in_IDX);
     ~EntityHitboxCache();
 
     CachedHitbox *GetHitbox(int id);
@@ -47,12 +49,12 @@ public:
     void UpdateBones();
 
     int m_nNumHitboxes;
+   int hit_idx;
     bool m_bModelSet;
     bool m_bInit;
     bool m_bSuccess;
-
     model_t *m_pLastModel;
-    CachedEntity *parent_ref; // TODO FIXME turn this into an actual reference
+    CachedEntity *parent_ref;
 
     bool m_VisCheckValidationFlags[CACHE_MAX_HITBOXES]{ false };
     bool m_VisCheck[CACHE_MAX_HITBOXES]{ false };
@@ -62,12 +64,4 @@ public:
     std::vector<matrix3x4_t> bones;
     bool bones_setup{ false };
 };
-
-extern EntityHitboxCache array[2048];
-inline EntityHitboxCache &Get(unsigned i)
-{
-    if (i > 2048)
-        throw std::out_of_range("Requested out-of-range entity hitbox cache entry!");
-    return array[i];
-}
 } // namespace hitbox_cache

--- a/include/hacks/ESP.hpp
+++ b/include/hacks/ESP.hpp
@@ -16,7 +16,7 @@ namespace hacks::shared::esp
 
 // Init
 void Init();
-
+void Shutdown();
 // Strings
 void SetEntityColor(CachedEntity *entity, const rgba_t &color);
 } // namespace hacks::shared::esp

--- a/include/hacks/Warp.hpp
+++ b/include/hacks/Warp.hpp
@@ -1,10 +1,12 @@
 #pragma once
 #include "settings/Bool.hpp"
 class INetMessage;
+
 namespace hacks::tf2::warp
 {
 extern bool in_rapidfire;
 extern bool in_warp;
+extern settings::Boolean dodge_projectile;
 void SendNetMessage(INetMessage &msg);
 void CL_SendMove_hook();
 } // namespace hacks::tf2::warp

--- a/include/helpers.hpp
+++ b/include/helpers.hpp
@@ -118,6 +118,7 @@ bool GetProjectileData(CachedEntity *weapon, float &speed, float &gravity, float
 bool IsVectorVisible(Vector a, Vector b, bool enviroment_only = false, CachedEntity *self = LOCAL_E, unsigned int mask = MASK_SHOT_HULL);
 // A Special function for navparser to check if a Vector is visible.
 bool IsVectorVisibleNavigation(Vector a, Vector b, unsigned int mask = MASK_SHOT_HULL);
+float ProjGravMult(int class_id, float x_speed);
 bool didProjectileHit(Vector start_point, Vector end_point, CachedEntity *entity, float projectile_size);
 Vector getShootPos(Vector angle);
 Vector GetForwardVector(Vector origin, Vector viewangles, float distance, CachedEntity *punch_entity = nullptr);

--- a/include/reclasses/C_TFWeaponBase.hpp
+++ b/include/reclasses/C_TFWeaponBase.hpp
@@ -40,22 +40,22 @@ public:
     inline static int GetWeaponID(IClientEntity *self)
     {
         typedef int (*fn_t)(IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(448, offsets::undefined, 448), 0)(self);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(449, offsets::undefined, 449), 0)(self);
     }
     inline static bool IsViewModelFlipped(IClientEntity *self)
     {
         typedef bool (*fn_t)(IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(497, offsets::undefined, 497), 0)(self);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(498, offsets::undefined, 498), 0)(self);
     }
     inline static IClientEntity *GetOwnerViaInterface(IClientEntity *self)
     {
         typedef IClientEntity *(*fn_t)(IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(455, offsets::undefined, 455), 0)(self);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(456, offsets::undefined, 456), 0)(self);
     }
     inline static bool UsesPrimaryAmmo(IClientEntity *self)
     {
         typedef bool (*fn_t)(IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(451, offsets::undefined, 451), 0)(self);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(452, offsets::undefined, 452), 0)(self);
     }
     inline static bool HasPrimaryAmmo(IClientEntity *self)
     {
@@ -65,22 +65,22 @@ public:
     inline static bool AreRandomCritsEnabled(IClientEntity *self)
     {
         typedef bool (*fn_t)(IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(470, offsets::undefined, 470), 0)(self);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(471, offsets::undefined, 470), 0)(self);
     }
     inline static bool CalcIsAttackCriticalHelper(IClientEntity *self)
     {
         typedef bool (*fn_t)(IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(464, offsets::undefined, 464), 0)(self);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(465, offsets::undefined, 465), 0)(self);
     }
     inline static bool CalcIsAttackCriticalHelperNoCrits(IClientEntity *self)
     {
         typedef bool (*fn_t)(IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(463, offsets::undefined, 463), 0)(self);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(464, offsets::undefined, 464), 0)(self);
     }
     inline static bool CanFireCriticalShot(IClientEntity *self, bool unknown1, IClientEntity *unknown2)
     {
         typedef bool (*fn_t)(IClientEntity *, bool, IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(493, offsets::undefined, 493), 0)(self, unknown1, unknown2);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(494, offsets::undefined, 494), 0)(self, unknown1, unknown2);
     }
     inline static float ApplyFireDelay(IClientEntity *self, float delay)
     {

--- a/include/reclasses/C_TFWeaponBaseGun.hpp
+++ b/include/reclasses/C_TFWeaponBaseGun.hpp
@@ -18,22 +18,22 @@ public:
     inline static float GetProjectileSpeed(IClientEntity *self)
     {
         typedef float (*fn_t)(IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(538, offsets::undefined, 538), 0)(self);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(539, offsets::undefined, 539), 0)(self);
     }
     inline static float GetWeaponSpread(IClientEntity *self)
     {
         typedef float (*fn_t)(IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(536, offsets::undefined, 536), 0)(self);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(537, offsets::undefined, 537), 0)(self);
     }
     inline static float GetProjectileGravity(IClientEntity *self)
     {
         typedef float (*fn_t)(IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(539, offsets::undefined, 539), 0)(self);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(540, offsets::undefined, 540), 0)(self);
     }
     inline static int LaunchGrenade(IClientEntity *self)
     {
         typedef int (*fn_t)(IClientEntity *);
-        return vfunc<fn_t>(self, offsets::PlatformOffset(552, offsets::undefined, 552), 0)(self);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(553, offsets::undefined, 553), 0)(self);
     }
 };
 } // namespace re

--- a/include/timer.hpp
+++ b/include/timer.hpp
@@ -13,7 +13,7 @@ class Timer
 {
 public:
     typedef std::chrono::system_clock clock;
-
+    std::chrono::time_point<clock> last{};
     inline Timer(){};
 
     inline bool check(unsigned ms) const
@@ -33,8 +33,5 @@ public:
     {
         last = clock::now();
     }
-
-public:
-    std::chrono::time_point<clock> last{};
 };
 #endif

--- a/src/CaptureLogic.cpp
+++ b/src/CaptureLogic.cpp
@@ -22,7 +22,7 @@ void Update()
         return;
     // Find flags if missing
     if (!flags[0].ent || !flags[1].ent)
-        for (auto &ent : entity_cache::valid_ents)
+        for (auto const &ent : entity_cache::valid_ents)
         {
             // We cannot identify a bad entity as a flag due to the unreliability of it
             if (ent->m_iClassID() != CL_CLASS(CCaptureFlag))
@@ -166,7 +166,7 @@ void Update()
         for (auto &entry : payloads)
             entry.clear();
 
-        for (auto &ent : entity_cache::valid_ents)
+        for (auto const &ent : entity_cache::valid_ents)
         {
 
             // Not the object we need or invalid (team)
@@ -192,7 +192,7 @@ std::optional<Vector> getClosestPayload(Vector source, int team)
     std::optional<Vector> best_pos;
 
     // Find best payload
-    for (auto payload : entry)
+    for (auto &payload : entry)
     {
         if (CE_BAD(payload) || payload->m_iClassID() != CL_CLASS(CObjectCartDispenser))
             continue;
@@ -240,7 +240,7 @@ void UpdateObjectiveResource()
     if (CE_GOOD(objective_resource) && objective_resource->m_iClassID() == CL_CLASS(CTFObjectiveResource))
         return;
     // Find ObjectiveResource and gamerules
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         if (ent->m_iClassID() != CL_CLASS(CTFObjectiveResource))
             continue;

--- a/src/angles.cpp
+++ b/src/angles.cpp
@@ -85,17 +85,17 @@ angle_data_s &data(const CachedEntity *entity)
 
 void Update()
 {
-    for (int i = 1; i <= MAX_PLAYERS; i++)
+    for (auto const &ent : entity_cache::player_cache)
     {
-        auto &d           = data_idx(i);
-        CachedEntity *ent = ENTITY(i);
+        auto &d = data_idx(ent->m_IDX);
+
         if (CE_GOOD(ent) && !CE_BYTE(ent, netvar.iLifeState))
         {
             if (!d.good)
             {
                 memset(&d, 0, sizeof(angle_data_s));
             }
-            if (i == g_IEngine->GetLocalPlayer())
+            if (ent->m_IDX == g_IEngine->GetLocalPlayer())
             {
                 d.push(current_user_cmd->viewangles);
             }

--- a/src/controlpointcontroller.cpp
+++ b/src/controlpointcontroller.cpp
@@ -28,7 +28,7 @@ void UpdateObjectiveResource()
     if (CE_GOOD(objective_resource) && objective_resource->m_iClassID() == CL_CLASS(CTFObjectiveResource))
         return;
     // Find ObjectiveResource and gamerules
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         if (ent->m_iClassID() != CL_CLASS(CTFObjectiveResource))
             continue;

--- a/src/copypasted/CSignature.cpp
+++ b/src/copypasted/CSignature.cpp
@@ -177,7 +177,7 @@ uintptr_t CSignature::GetSignature(const char *chPattern, sharedobj::SharedObjec
         int fd       = open(obj.path.c_str(), O_RDONLY);
         void *module = mmap(NULL, lseek(fd, 0, SEEK_END), PROT_READ, MAP_SHARED, fd, 0);
         if ((unsigned) module == 0xffffffff)
-            return NULL;
+            return {};
         link_map *moduleMap = obj.lmap;
 
         // static void *module = (void *)moduleMap->l_addr;
@@ -197,7 +197,7 @@ uintptr_t CSignature::GetSignature(const char *chPattern, sharedobj::SharedObjec
     // (subbing the mmapped one and replacing it with the dlopened one.
     uintptr_t patr = dwFindPattern(((uintptr_t) object.module) + object.textOffset, ((uintptr_t) object.module) + object.textOffset + object.textSize, chPattern);
     if (!patr)
-        return NULL;
+        return {};
     return patr - (uintptr_t)(object.module) + object.moduleMap->l_addr;
 }
 //===================================================================================

--- a/src/crits.cpp
+++ b/src/crits.cpp
@@ -278,7 +278,7 @@ bool shouldMeleeCrit()
         }
         else
         {
-            for (auto &ent_data : hacks::tf2::backtrack::bt_data)
+            for (auto const &ent_data : hacks::tf2::backtrack::bt_data)
             {
                 for (auto &tick : ent_data)
                 {
@@ -662,13 +662,13 @@ void CreateMove()
     cached_damage = g_pPlayerResource->GetDamage(g_pLocalPlayer->entity_idx) - melee_damage;
 
     // We need to update player states regardless, else we can't sync the observed crit chance
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        CachedEntity *ent = ENTITY(i);
+        
         // no valid check needed, GetHealth only uses m_IDX
         if (g_pPlayerResource->GetHealth(ent))
         {
-            auto &status = player_status_list[i - 1];
+            auto &status = player_status_list[ent->m_IDX - 1];
             // Only sync if not updated recently in player_hurt
             // new health is bigger,
             // or they changed classes. We do the rest in player_hurt

--- a/src/entitycache.cpp
+++ b/src/entitycache.cpp
@@ -135,7 +135,7 @@ namespace entity_cache
 {
 std::unordered_map<u_int16_t, CachedEntity> array;
 std::vector<CachedEntity *> valid_ents;
-std::map<Vector, CachedEntity *> proj_map;
+std::vector<std::tuple<Vector,CachedEntity*>> proj_map;
 std::vector<CachedEntity *> skip_these;
 std::vector<CachedEntity *> player_cache;
 u_int16_t previous_max = 0;
@@ -178,9 +178,9 @@ void Update()
         {
             if (g_Settings.bInvalid || !(g_IEntityList->GetClientEntity(i)) || !(g_IEntityList->GetClientEntity(i)->GetClientClass()->m_ClassID))
                 continue;
-            array.emplace(std::make_pair(i, CachedEntity{i}));
+            if (array.find(i) == array.end())
+                array.emplace(std::make_pair(i, CachedEntity{ i }));
             array[i].Update();
-            
             if (CE_GOOD((&array[i])))
             {
                 array[i].hitboxes.UpdateBones();
@@ -242,17 +242,16 @@ void dodgeProj(CachedEntity *proj_ptr)
         }
         if (min_displacement < 20000)
         {
-            proj_map.insert({ eav, proj_ptr });
-            skip_these.push_back(proj_ptr);
+            proj_map.emplace_back((std::make_tuple(eav,proj_ptr)));
+            skip_these.emplace_back(proj_ptr);
         }
         else
-            skip_these.push_back(proj_ptr);
+            skip_these.emplace_back(proj_ptr);
     }
 }
 void Invalidate()
 {
     array.clear();
-    
 }
 void Shutdown()
 {

--- a/src/entitycache.cpp
+++ b/src/entitycache.cpp
@@ -18,7 +18,7 @@ bool IsProjectileACrit(CachedEntity *ent)
         return CE_BYTE(ent, netvar.Grenade_bCritical);
     return CE_BYTE(ent, netvar.Rocket_bCritical);
 }
-// This method of const'ing the index is weird.
+
 CachedEntity::CachedEntity(u_int16_t idx) : m_IDX(idx), hitboxes(hitbox_cache::EntityHitboxCache{ idx })
 {
 #if PROXY_ENTITY != true

--- a/src/entitycache.cpp
+++ b/src/entitycache.cpp
@@ -178,9 +178,9 @@ void Update()
         {
             if (g_Settings.bInvalid || !(g_IEntityList->GetClientEntity(i)) || !(g_IEntityList->GetClientEntity(i)->GetClientClass()->m_ClassID))
                 continue;
-            CachedEntity test(i);
-            test.Update();
-            array.emplace(std::make_pair(i, test));
+            array.emplace(std::make_pair(i, CachedEntity{i}));
+            array[i].Update();
+            
             if (CE_GOOD((&array[i])))
             {
                 array[i].hitboxes.UpdateBones();
@@ -249,7 +249,11 @@ void dodgeProj(CachedEntity *proj_ptr)
             skip_these.push_back(proj_ptr);
     }
 }
-
+void Invalidate()
+{
+    array.clear();
+    
+}
 void Shutdown()
 {
     array.clear();

--- a/src/entityhitboxcache.cpp
+++ b/src/entityhitboxcache.cpp
@@ -12,12 +12,10 @@
 
 namespace hitbox_cache
 {
-
-EntityHitboxCache::EntityHitboxCache() : parent_ref(&entity_cache::Get(((unsigned) this - (unsigned) &hitbox_cache::array) / sizeof(EntityHitboxCache)))
+EntityHitboxCache::EntityHitboxCache(int in_IDX) : hit_idx(in_IDX)
 {
     Reset();
 }
-
 int EntityHitboxCache::GetNumHitboxes()
 {
     if (!m_bInit)
@@ -53,8 +51,8 @@ void EntityHitboxCache::Init()
     model_t *model;
     studiohdr_t *shdr;
     mstudiohitboxset_t *set;
-
-    m_bInit = true;
+    m_bInit    = true;
+    parent_ref = &(entity_cache::array[hit_idx]);
     if (CE_BAD(parent_ref))
         return;
     model = (model_t *) RAW_ENT(parent_ref)->GetModel();
@@ -104,11 +102,11 @@ bool EntityHitboxCache::VisibilityCheck(int id)
 
 static settings::Int setupbones_time{ "source.setupbones-time", "2" };
 
-static std::mutex setupbones_mutex;
-
 void EntityHitboxCache::UpdateBones()
 {
     // Do not run for bad ents/non player ents
+    if (!m_bInit)
+        Init();
     if (CE_BAD(parent_ref) || parent_ref->m_Type() != ENTITY_PLAYER)
         return;
     auto bone_ptr = GetBones();
@@ -239,8 +237,6 @@ CachedHitbox *EntityHitboxCache::GetHitbox(int id)
     m_CacheValidationFlags[id] = true;
     return &m_CacheInternal[id];
 }
-
-EntityHitboxCache array[MAX_ENTITIES]{};
 
 void Update()
 {

--- a/src/flagcontroller.cpp
+++ b/src/flagcontroller.cpp
@@ -22,7 +22,7 @@ void Update()
         return;
     // Find flags if missing
     if (!flags[0].ent || !flags[1].ent)
-        for (auto &ent : entity_cache::valid_ents)
+        for (auto const &ent : entity_cache::valid_ents)
         {
 
             // We cannot identify a bad entity as a flag due to the unreliability of it

--- a/src/hacks/AntiAntiAim.cpp
+++ b/src/hacks/AntiAntiAim.cpp
@@ -16,9 +16,9 @@ std::array<CachedEntity *, 32> sniperdot_array;
 
 static inline void modifyAngles()
 {
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &player : entity_cache::player_cache)
     {
-        auto player = ENTITY(i);
+        
         if (CE_BAD(player) || !player->m_bAlivePlayer() || !player->m_bEnemy() || !player->player_info.friendsID)
             continue;
         auto &data  = resolver_map[player->player_info.friendsID];
@@ -212,7 +212,7 @@ static void hook()
         // "DT_TFPlayer", "tfnonlocaldata"
         if (!strcmp(pszName, "DT_TFPlayer"))
         {
-            for (int i = 0; i < pClass->m_pRecvTable->m_nProps; i++)
+            for (int i = 0; i < pClass->m_pRecvTable->m_nProps; ++i)
             {
                 RecvPropRedef *pProp1 = (RecvPropRedef *) &(pClass->m_pRecvTable->m_pProps[i]);
                 if (!pProp1)

--- a/src/hacks/AntiBackstab.cpp
+++ b/src/hacks/AntiBackstab.cpp
@@ -54,19 +54,15 @@ float GetAngle(CachedEntity *spy)
 
 CachedEntity *ClosestSpy()
 {
-    CachedEntity *closest, *ent;
+    CachedEntity *closest;
     float closest_dist, dist;
 
     closest      = nullptr;
     closest_dist = 0.0f;
 
-    for (int i = 1; i < PLAYER_ARRAY_SIZE && i < g_IEntityList->GetHighestEntityIndex(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        ent = ENTITY(i);
-        if (CE_BAD(ent))
-            continue;
-        if (CE_BYTE(ent, netvar.iLifeState))
-            continue;
+        
         bool ispyro  = false;
         bool isheavy = false;
         if (CE_INT(ent, netvar.iClass) != tf_class::tf_spy)

--- a/src/hacks/AntiCheat.cpp
+++ b/src/hacks/AntiCheat.cpp
@@ -52,21 +52,19 @@ void CreateMove()
         return;
     angles::Update();
     ac::aimbot::player_orgs().clear();
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent : entity_cache::player_cache)
     {
-        if (skip_local && (i == g_IEngine->GetLocalPlayer()))
+        if (skip_local && ent == LOCAL_E)
             continue;
-        CachedEntity *ent = ENTITY(i);
+
         if (CE_GOOD(ent))
         {
-            if (ent->m_bAlivePlayer())
+
+            if (player_tools::shouldTarget(ent) || ent == LOCAL_E)
             {
-                if (player_tools::shouldTarget(ent) || ent == LOCAL_E)
-                {
-                    ac::aimbot::Update(ent);
-                    ac::antiaim::Update(ent);
-                    ac::bhop::Update(ent);
-                }
+                ac::aimbot::Update(ent);
+                ac::antiaim::Update(ent);
+                ac::bhop::Update(ent);
             }
         }
     }

--- a/src/hacks/AntiDisguise.cpp
+++ b/src/hacks/AntiDisguise.cpp
@@ -23,9 +23,8 @@ void cm()
     if (!*enable && !*no_invisibility)
         return;
 
-    for (int i = 0; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        ent = ENTITY(i);
         if (CE_BAD(ent) || ent == LOCAL_E || ent->m_Type() != ENTITY_PLAYER || CE_INT(ent, netvar.iClass) != tf_class::tf_spy)
         {
             continue;

--- a/src/hacks/AutoBackstab.cpp
+++ b/src/hacks/AutoBackstab.cpp
@@ -108,7 +108,7 @@ int ClosestDistanceHitbox(CachedEntity *target)
 {
     int closest        = -1;
     float closest_dist = FLT_MAX, dist = 0.0f;
-    for (int i = pelvis; i < spine_3; i++)
+    for (int i = pelvis; i < spine_3; ++i)
     {
         auto hitbox = target->hitboxes.GetHitbox(i);
         if (!hitbox)
@@ -126,7 +126,7 @@ int ClosestDistanceHitbox(hacks::tf2::backtrack::BacktrackData btd)
 {
     int closest        = -1;
     float closest_dist = FLT_MAX, dist = 0.0f;
-    for (int i = pelvis; i < spine_3; i++)
+    for (int i = pelvis; i < spine_3; ++i)
     {
         dist = g_pLocalPlayer->v_Eye.DistTo(btd.hitboxes.at(i).center);
         if (dist < closest_dist)
@@ -262,9 +262,9 @@ static bool doRageBackstab()
     float swingrange = re::C_TFWeaponBaseMelee::GetSwingRange(RAW_ENT(LOCAL_W));
     // AimAt Autobackstab
     {
-        for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+        for (auto const &ent: entity_cache::player_cache)
         {
-            auto ent = ENTITY(i);
+         
             if (CE_BAD(ent) || ent->m_flDistance() > swingrange * 4 || !ent->m_bEnemy() || !ent->m_bAlivePlayer() || g_pLocalPlayer->entity_idx == ent->m_IDX || IsPlayerInvulnerable(ent))
                 continue;
             if (!player_tools::shouldTarget(ent))
@@ -278,7 +278,7 @@ static bool doRageBackstab()
             auto angle     = GetAimAtAngles(g_pLocalPlayer->v_Eye, aim_pos, LOCAL_E);
             if (!angleCheck(ent, std::nullopt, angle) && !canFaceStab(ent))
                 continue;
-            if (doSwingTraceAngle(angle, trace) && ((IClientEntity *) trace.m_pEnt)->entindex() == i)
+            if (doSwingTraceAngle(angle, trace) && ((IClientEntity *) trace.m_pEnt)->entindex() == ent->m_IDX)
             {
                 current_user_cmd->buttons |= IN_ATTACK;
                 g_pLocalPlayer->bUseSilentAngles = true;
@@ -353,12 +353,12 @@ static bool doBacktrackStab(bool legit = false)
     // Set for our filter
     legit_stab = legit;
     // Get the Best tick
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
         // Found a target, break out
         if (stab_ent)
             break;
-        CachedEntity *ent = ENTITY(i);
+        
         // Targeting checks
         if (CE_BAD(ent) || !ent->m_bAlivePlayer() || !ent->m_bEnemy() || !player_tools::shouldTarget(ent) || IsPlayerInvulnerable(ent))
             continue;

--- a/src/hacks/AutoDeadringer.cpp
+++ b/src/hacks/AutoDeadringer.cpp
@@ -21,7 +21,7 @@ int NearbyEntities()
     int ret = 0;
     if (CE_BAD(LOCAL_E) || CE_BAD(LOCAL_W))
         return ret;
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
 
         if (ent == LOCAL_E)
@@ -52,7 +52,7 @@ static void CreateMove()
     else
         shouldm2 = false;
 
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         if (!IsProjectile(ent) && !ent->m_bGrenadeProjectile())
             continue;

--- a/src/hacks/AutoDetonator.cpp
+++ b/src/hacks/AutoDetonator.cpp
@@ -85,7 +85,7 @@ void CreateMove()
     targets.clear();
 
     // Cycle through the ents and search for valid ents
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
 
         // Check if ent is a flare or suitable target and push to respective

--- a/src/hacks/AutoHeal.cpp
+++ b/src/hacks/AutoHeal.cpp
@@ -97,9 +97,9 @@ int BulletDangerValue(CachedEntity *patient)
         return 0;
     bool any_zoomed_snipers = false;
     // Find dangerous snipers in other team
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        CachedEntity *ent = ENTITY(i);
+        
         if (CE_BAD(ent))
             continue;
         if (!ent->m_bAlivePlayer() || !ent->m_bEnemy())
@@ -142,9 +142,9 @@ int FireDangerValue(CachedEntity *patient)
     uint8_t should_switch = 0;
     if (auto_vacc_pop_if_pyro)
     {
-        for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+        for (auto const &ent: entity_cache::player_cache)
         {
-            CachedEntity *ent = ENTITY(i);
+            
             if (CE_BAD(ent))
                 continue;
             if (!ent->m_bEnemy())
@@ -215,7 +215,7 @@ int BlastDangerValue(CachedEntity *patient)
         return 1;
     }
     // Find rockets/pipes nearby
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         if (!ent->m_bEnemy())
             continue;
@@ -247,7 +247,7 @@ int NearbyEntities()
     int ret = 0;
     if (CE_BAD(LOCAL_E) || CE_BAD(LOCAL_W))
         return ret;
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
 
         if (ent == LOCAL_E)
@@ -424,11 +424,12 @@ bool IsVaccinator()
 
 void UpdateData()
 {
-    for (int i = 1; i <= MAX_PLAYERS; i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
+        int i = ent->m_IDX;
         if (reset_cd[i].test_and_set(10000))
             data[i] = {};
-        CachedEntity *ent = ENTITY(i);
+        
         if (CE_GOOD(ent) && ent->m_bAlivePlayer())
         {
             int health = ent->m_iHealth();
@@ -577,12 +578,12 @@ int BestTarget()
     int best_score = INT_MIN;
     if (steamid_only)
         return best;
-    for (int i = 0; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        int score = HealingPriority(i);
+        int score = HealingPriority(ent->m_IDX);
         if (score > best_score && score != -1)
         {
-            best       = i;
+            best       = ent->m_IDX;
             best_score = score;
         }
     }
@@ -622,10 +623,10 @@ void CreateMove()
         }
         if (current_id != steamid)
         {
-            for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+            for (auto const &ent: entity_cache::player_cache)
             {
-                CachedEntity *ent = ENTITY(i);
-                if (CE_BAD(ent) || !ent->player_info.friendsID)
+                int i = ent->m_IDX;
+                if (!ent->player_info.friendsID)
                     continue;
                 if (ent->player_info.friendsID == steamid && CanHeal(i))
                 {

--- a/src/hacks/AutoItem.cpp
+++ b/src/hacks/AutoItem.cpp
@@ -81,7 +81,7 @@ void Lock()
     if (!checkAchMgr())
         return;
     g_ISteamUserStats->RequestCurrentStats();
-    for (int i = 0; i < g_IAchievementMgr->GetAchievementCount(); i++)
+    for (int i = 0; i < g_IAchievementMgr->GetAchievementCount(); ++i)
     {
         g_ISteamUserStats->ClearAchievement(g_IAchievementMgr->GetAchievementByIndex(i)->GetName());
     }
@@ -93,7 +93,7 @@ void Unlock()
 {
     if (!checkAchMgr())
         return;
-    for (int i = 0; i < g_IAchievementMgr->GetAchievementCount(); i++)
+    for (int i = 0; i < g_IAchievementMgr->GetAchievementCount(); ++i)
     {
         g_IAchievementMgr->AwardAchievement(g_IAchievementMgr->GetAchievementByIndex(i)->GetAchievementID());
     }
@@ -375,7 +375,7 @@ CatCommand dump_achievement("achievement_dump", "Dump achievements to file (deve
                                 std::ofstream out("/tmp/cathook_achievements.txt", std::ios::out);
                                 if (out.bad())
                                     return;
-                                for (int i = 0; i < g_IAchievementMgr->GetAchievementCount(); i++)
+                                for (int i = 0; i < g_IAchievementMgr->GetAchievementCount(); ++i)
                                 {
                                     out << '[' << i << "] " << g_IAchievementMgr->GetAchievementByIndex(i)->GetName() << ' ' << g_IAchievementMgr->GetAchievementByIndex(i)->GetAchievementID() << "\n";
                                 }
@@ -422,7 +422,7 @@ CatCommand lock_single("achievement_lock_single", "Locks single achievement by I
 
                            int index = -1;
                            if (ach)
-                               for (int i = 0; i < g_IAchievementMgr->GetAchievementCount(); i++)
+                               for (int i = 0; i < g_IAchievementMgr->GetAchievementCount(); ++i)
                                {
                                    auto ach2 = g_IAchievementMgr->GetAchievementByIndex(i);
                                    if (ach2->GetAchievementID() == id)

--- a/src/hacks/AutoParty.cpp
+++ b/src/hacks/AutoParty.cpp
@@ -136,14 +136,14 @@ void repopulate(std::string str)
         }
         auto &peer_data                           = ipc::peer->memory->peer_user_data;
         std::vector<struct ipc_peer> sorted_peers = {};
-        for (int i = 0; i < cat_ipc::max_peers; i++)
+        for (int i = 0; i < cat_ipc::max_peers; ++i)
         {
             ipc::user_data_s &data = peer_data[i];
             struct ipc_peer peer   = { .friendid = data.friendid, .ts_injected = data.ts_injected };
             sorted_peers.push_back(peer);
         }
         std::sort(sorted_peers.begin(), sorted_peers.end(), compare_ts);
-        for (int i = 0; i < *ipc_count; i++)
+        for (int i = 0; i < *ipc_count; ++i)
         {
             party_hosts.push_back(sorted_peers[i].friendid);
         }
@@ -166,7 +166,7 @@ void repopulate(std::string str)
 bool is_host()
 {
     uint32 id = g_ISteamUser->GetSteamID().GetAccountID();
-    for (int i = 0; i < party_hosts.size(); i++)
+    for (int i = 0; i < party_hosts.size(); ++i)
     {
         if (party_hosts.at(i) == id)
         {
@@ -180,7 +180,7 @@ bool is_host()
 void find_party()
 {
     log_debug("No party members and not a party host; requesting to join with each party host");
-    for (int i = 0; i < party_hosts.size(); i++)
+    for (int i = 0; i < party_hosts.size(); ++i)
     {
         hack::ExecuteCommand("tf_party_request_join_user " + std::to_string(party_hosts[i]));
     }
@@ -285,7 +285,7 @@ void party_routine()
                     if (*kick_rage)
                     {
                         bool should_ret = false;
-                        for (int i = 0; i < members.size(); i++)
+                        for (int i = 0; i < members.size(); ++i)
                         {
                             auto &pl = playerlist::AccessData(members[i]);
                             if (pl.state == playerlist::k_EState::RAGE)
@@ -318,7 +318,7 @@ void party_routine()
                         logging::Info("AutoParty: %s", message.c_str());
                         if (*message_kicks)
                             client->SendPartyChat(message.c_str());
-                        for (int i = 0; i < num_to_kick; i++)
+                        for (int i = 0; i < num_to_kick; ++i)
                         {
                             CSteamID id = CSteamID(members[members.size() - (1 + i)], EUniverse::k_EUniversePublic, EAccountType::k_EAccountTypeIndividual);
                             client->KickPlayer(id);

--- a/src/hacks/AutoReflect.cpp
+++ b/src/hacks/AutoReflect.cpp
@@ -152,7 +152,7 @@ void CreateMove()
     float closest_dist = 0.0f;
     Vector closest_vec;
     // Loop to find the closest entity
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
 
         // Find an ent from the for loops current tick

--- a/src/hacks/AutoSticky.cpp
+++ b/src/hacks/AutoSticky.cpp
@@ -124,7 +124,7 @@ void CreateMove()
     targets.clear();
 
     // Cycle through the ents and search for valid ents
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         // Assign the for loops index to an ent
 

--- a/src/hacks/AutoTaunt.cpp
+++ b/src/hacks/AutoTaunt.cpp
@@ -41,7 +41,7 @@ public:
         if (GetPlayerForUserID(event->GetInt("attacker")) == g_IEngine->GetLocalPlayer())
         {
             bool nearby = false;
-            for (auto &ent : entity_cache::valid_ents)
+            for (auto const &ent : entity_cache::valid_ents)
             {
                 if (CE_VALID(ent) && (ent->m_Type() == ENTITY_PLAYER || ent->m_iClassID() == CL_CLASS(CObjectSentrygun)) && ent->m_bEnemy() && ent->m_bAlivePlayer())
                 {

--- a/src/hacks/AutoViewmodel.cpp
+++ b/src/hacks/AutoViewmodel.cpp
@@ -19,9 +19,9 @@ void CreateMove()
 
     // Should we test if a flip would help?
     bool should_test_viewmodel = true;
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        CachedEntity *ent = ENTITY(i);
+        
         if (CE_BAD(ent) || !ent->m_bEnemy() || !ent->m_bAlivePlayer() || ent == LOCAL_E)
             continue;
         auto eye   = g_pLocalPlayer->v_Eye;
@@ -39,9 +39,8 @@ void CreateMove()
     if (should_test_viewmodel)
     {
         cl_flipviewmodels->SetValue(!cl_flipviewmodels->GetBool());
-        for (int i = 0; i <= g_IEngine->GetMaxClients(); i++)
+        for (auto const &ent: entity_cache::player_cache)
         {
-            CachedEntity *ent = ENTITY(i);
             if (CE_BAD(ent) || !ent->m_bEnemy() || !ent->m_bAlivePlayer() || ent == LOCAL_E)
                 continue;
             auto eye   = g_pLocalPlayer->v_Eye;

--- a/src/hacks/Backtrack.cpp
+++ b/src/hacks/Backtrack.cpp
@@ -195,7 +195,7 @@ void MoveToTick(BacktrackData data)
     // Mark all the hitboxes as valid so we don't recalc them and use the old data
     // We already have
     target->hitboxes.m_CacheInternal.resize(data.hitboxes.size());
-    for (int i = hitbox_t::head; i <= foot_R; i++)
+    for (int i = hitbox_t::head; i <= foot_R; ++i)
     {
         target->hitboxes.m_CacheValidationFlags[i] = true;
         target->hitboxes.m_CacheInternal.at(i)     = data.hitboxes.at(i);
@@ -279,9 +279,9 @@ void CreateMoveEarly()
     if ((int) bt_data.size() != g_IEngine->GetMaxClients())
         bt_data.resize(g_IEngine->GetMaxClients());
 
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        CachedEntity *ent = ENTITY(i);
+        int i = ent->m_IDX;
         int index         = i - 1;
 
         auto &ent_data = bt_data[index];
@@ -306,7 +306,7 @@ void CreateMoveEarly()
         // Copy bones (for chams/glow)
         data.bones = ent->hitboxes.bones;
 
-        for (int i = head; i <= foot_R; i++)
+        for (int i = head; i <= foot_R; ++i)
             data.hitboxes.at(i) = *ent->hitboxes.GetHitbox(i);
 
         ent_data.insert(ent_data.begin(), data);
@@ -343,7 +343,7 @@ void CreateMoveLate()
     if (!set_data && !g_pLocalPlayer->bUseSilentAngles)
     {
         float cursor_distance = FLT_MAX;
-        for (auto &ent_data : bt_data)
+        for (auto const &ent_data : bt_data)
         {
             for (auto &tick_data : ent_data)
             {

--- a/src/hacks/CatBot.cpp
+++ b/src/hacks/CatBot.cpp
@@ -118,7 +118,7 @@ std::vector<std::string> config_list(std::string in)
         return config_vec;
     }
 
-    for (i = 0; i < results.gl_pathc; i++)
+    for (i = 0; i < results.gl_pathc; ++i)
         // /configs/ is 9 extra chars i have to remove
         config_vec.push_back(std::string(results.gl_pathv[i]).substr(paths::getDataPath().length() + 9));
 
@@ -564,9 +564,9 @@ void reportall()
         patch.Patch();
         patched_report = true;
     }
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        CachedEntity *ent = ENTITY(i);
+       
         // We only want a nullptr check since dormant entities are still on the
         // server
         if (!ent)
@@ -576,7 +576,7 @@ void reportall()
         if (ent == LOCAL_E)
             continue;
         player_info_s info;
-        if (GetPlayerInfo(i, &info) && info.friendsID)
+        if (GetPlayerInfo(ent->m_IDX, &info) && info.friendsID)
         {
             if (!player_tools::shouldTargetSteamId(info.friendsID))
                 continue;
@@ -634,9 +634,8 @@ void smart_crouch()
     static bool crouch = false;
     if (crouchcdr.test_and_set(2000))
     {
-        for (int i = 0; i <= g_IEngine->GetMaxClients(); i++)
+        for (auto const &ent: entity_cache::player_cache)
         {
-            auto ent = ENTITY(i);
             if (CE_BAD(ent) || ent->m_Type() != ENTITY_PLAYER || ent->m_iTeam() == LOCAL_E->m_iTeam() || !(ent->hitboxes.GetHitbox(0)) || !(ent->m_bAlivePlayer()) || !player_tools::shouldTarget(ent))
                 continue;
             bool failedvis = false;
@@ -669,7 +668,7 @@ CatCommand print_ammo("debug_print_ammo", "debug",
                           if (CE_BAD(LOCAL_E) || !LOCAL_E->m_bAlivePlayer() || CE_BAD(LOCAL_W))
                               return;
                           logging::Info("Current slot: %d", re::C_BaseCombatWeapon::GetSlot(RAW_ENT(LOCAL_W)));
-                          for (int i = 0; i < 10; i++)
+                          for (int i = 0; i < 10; ++i)
                               logging::Info("Ammo Table %d: %d", i, CE_INT(LOCAL_E, netvar.m_iAmmo + i * 4));
                       });
 static Timer disguise{};
@@ -786,8 +785,9 @@ void update()
         ipc_list.clear();
         int count_total = 0;
 
-        for (int i = 1; i <= g_IEngine->GetMaxClients(); ++i)
+        for (auto const &ent: entity_cache::player_cache)
         {
+            int i = ent->m_IDX;
             if (g_IEntityList->GetClientEntity(i))
                 ++count_total;
             else
@@ -825,7 +825,7 @@ void update()
                     auto &peer_mem = ipc::peer->memory;
 
                     // Iterate all ipc peers
-                    for (unsigned i = 0; i < cat_ipc::max_peers; i++)
+                    for (unsigned i = 0; i < cat_ipc::max_peers; ++i)
                     {
                         // If that ipc peer is alive and in has the steamid of that player
                         if (!peer_mem->peer_data[i].free && peer_mem->peer_user_data[i].friendid == id)

--- a/src/hacks/DominateMark.cpp
+++ b/src/hacks/DominateMark.cpp
@@ -22,10 +22,9 @@ static InitRoutine init([]() {
             if (CE_BAD(LOCAL_E))
                 return;
             re::CTFPlayerShared *shared_player = &re::C_BasePlayer::shared_(RAW_ENT(LOCAL_E));
-            for (int i = 0; i <= g_IEngine->GetMaxClients(); i++)
+            for (auto const &ent: entity_cache::player_cache)
             {
-                CachedEntity *ent = ENTITY(i);
-                if (CE_VALID(ent) && ent->m_bAlivePlayer() && re::CTFPlayerShared::IsDominatingPlayer(shared_player, i))
+                if (CE_VALID(ent) && ent->m_bAlivePlayer() && re::CTFPlayerShared::IsDominatingPlayer(shared_player, ent->m_IDX))
                 {
                     float size;
                     if (!ent->hitboxes.GetHitbox(0))

--- a/src/hacks/ESP.cpp
+++ b/src/hacks/ESP.cpp
@@ -90,8 +90,7 @@ void __attribute__((fastcall)) DrawBox(CachedEntity *ent, const rgba_t &clr);
 void BoxCorners(int minx, int miny, int maxx, int maxy, const rgba_t &color, bool transparent);
 bool GetCollide(CachedEntity *ent);
 
-// Storage array for keeping strings and other data
-std::unordered_map<CachedEntity *, ESPData> data;
+
 // Storage vars for entities that need to be re-drawn
 std::vector<std::pair<int, float>> entities_need_repaint{};
 
@@ -106,7 +105,25 @@ const std::string bonenames_spine[]  = { "bip_pelvis", "bip_spine_0", "bip_spine
 const std::string bonenames_arm_r[]  = { "bip_upperArm_R", "bip_lowerArm_R", "bip_hand_R" };
 const std::string bonenames_arm_l[]  = { "bip_upperArm_L", "bip_lowerArm_L", "bip_hand_L" };
 const std::string bonenames_up[]     = { "bip_upperArm_R", "bip_spine_3", "bip_upperArm_L" };
-
+class ESPString
+{
+public:
+    std::string data;
+    rgba_t color{ colors::empty };
+};
+class ESPData
+{
+public:
+    int string_count{ 0 };
+    std::array<ESPString, 16> strings{};
+    rgba_t color{ colors::empty };
+    bool needs_paint{ false };
+    bool has_collide{ false };
+    Vector collide_max{ 0, 0, 0 };
+    Vector collide_min{ 0, 0, 0 };
+    bool transparent{ false };
+};
+std::unordered_map<CachedEntity *, ESPData> data;
 // Dont fully understand struct but a guess is a group of something.
 // I will return once I have enough knowlage to reverse this.
 // NOTE: No idea on why we cant just use gethitbox and use the displacement on
@@ -1508,7 +1525,10 @@ void _FASTCALL Draw3DBox(CachedEntity *ent, const rgba_t &clr)
         draw::Line((points[i + 3].x), (points[i + 3].y), (points[i % 4 + 4].x) - (points[i + 3].x), (points[i % 4 + 4].y) - (points[i + 3].y), draw_clr, 0.5f);
     }
 }
-
+void Shutdown()
+{
+    data.clear();
+}
 // Draw a box around a player
 void _FASTCALL DrawBox(CachedEntity *ent, const rgba_t &clr)
 {

--- a/src/hacks/ESP.cpp
+++ b/src/hacks/ESP.cpp
@@ -90,28 +90,6 @@ void __attribute__((fastcall)) DrawBox(CachedEntity *ent, const rgba_t &clr);
 void BoxCorners(int minx, int miny, int maxx, int maxy, const rgba_t &color, bool transparent);
 bool GetCollide(CachedEntity *ent);
 
-// Strings
-class ESPString
-{
-public:
-    std::string data;
-    rgba_t color{ colors::empty };
-};
-
-// Cached data
-class ESPData
-{
-public:
-    int string_count{ 0 };
-    std::array<ESPString, 16> strings{};
-    rgba_t color{ colors::empty };
-    bool needs_paint{ false };
-    bool has_collide{ false };
-    Vector collide_max{ 0, 0, 0 };
-    Vector collide_min{ 0, 0, 0 };
-    bool transparent{ false };
-};
-
 // Storage array for keeping strings and other data
 std::unordered_map<CachedEntity *, ESPData> data;
 // Storage vars for entities that need to be re-drawn
@@ -316,10 +294,7 @@ static void cm()
     if (!*enable)
         return;
     if (CE_BAD(LOCAL_E))
-    {
-        data.clear();
         return;
-    }
 
     // Update entites every 1/5s
     const bool entity_tick = g_GlobalVars->tickcount % TIME_TO_TICKS(0.20f) == 0;

--- a/src/hacks/ESP.cpp
+++ b/src/hacks/ESP.cpp
@@ -112,13 +112,10 @@ public:
     bool transparent{ false };
 };
 
-// Unknown
-std::mutex threadsafe_mutex;
 // Storage array for keeping strings and other data
-std::array<ESPData, 2048> data;
+std::unordered_map<CachedEntity *, ESPData> data;
 // Storage vars for entities that need to be re-drawn
 std::vector<std::pair<int, float>> entities_need_repaint{};
-std::mutex entities_need_repaint_mutex{};
 
 // :b:one stuff needs to be up here as puting it in the header for sorting would
 // be a pain.
@@ -137,10 +134,12 @@ const std::string bonenames_up[]     = { "bip_upperArm_R", "bip_spine_3", "bip_u
 // NOTE: No idea on why we cant just use gethitbox and use the displacement on
 // that insted of having all this extra code. Shouldnt gethitbox use cached
 // hitboxes, if so it should be nicer on performance
-struct bonelist_s
+class bonelist_s
 {
+private:
     bool setup{ false };
     bool success{ false };
+    std::unordered_map<std::string, int> bones{};
     int leg_r[3]{ 0 };
     int leg_l[3]{ 0 };
     int bottom[3]{ 0 };
@@ -149,103 +148,75 @@ struct bonelist_s
     int arm_l[3]{ 0 };
     int up[3]{ 0 };
 
-    void Setup(const studiohdr_t *hdr)
-    {
-        if (!hdr)
-        {
-            setup = true;
-            return;
-        }
-        std::unordered_map<std::string, int> bones{};
-        for (int i = 0; i < hdr->numbones; i++)
-        {
-            bones[std::string(hdr->pBone(i)->pszName())] = i;
-        }
-        try
-        {
-            for (int i = 0; i < 3; i++)
-                leg_r[i] = bones.at(bonenames_leg_r[i]);
-            for (int i = 0; i < 3; i++)
-                leg_l[i] = bones.at(bonenames_leg_l[i]);
-            for (int i = 0; i < 3; i++)
-                bottom[i] = bones.at(bonenames_bottom[i]);
-            for (int i = 0; i < 7; i++)
-                spine[i] = bones.at(bonenames_spine[i]);
-            for (int i = 0; i < 3; i++)
-                arm_r[i] = bones.at(bonenames_arm_r[i]);
-            for (int i = 0; i < 3; i++)
-                arm_l[i] = bones.at(bonenames_arm_l[i]);
-            for (int i = 0; i < 3; i++)
-                up[i] = bones.at(bonenames_up[i]);
-            success = true;
-        }
-        catch (std::exception &ex)
-        {
-            logging::Info("Bone list exception: %s", ex.what());
-        }
-        setup = true;
-    }
-
-    void _FASTCALL DrawBoneList(const matrix3x4_t *bones, int *in, int size, const rgba_t &color)
-    {
-        Vector last_screen;
-        Vector current_screen;
-        for (int i = 0; i < size; i++)
-        {
-            const auto &bone = bones[in[i]];
-            Vector position(bone[0][3], bone[1][3], bone[2][3]);
-            if (!draw::WorldToScreen(position, current_screen))
-            {
-                return;
-            }
-            if (i > 0)
-            {
-                draw::Line(last_screen.x, last_screen.y, current_screen.x - last_screen.x, current_screen.y - last_screen.y, color, *bones_thickness);
-            }
-            last_screen = current_screen;
-        }
-    }
-
-    void _FASTCALL Draw(CachedEntity *ent, const rgba_t &color)
-    {
-        const model_t *model = RAW_ENT(ent)->GetModel();
-        if (not model)
-        {
-            return;
-        }
-
-        studiohdr_t *hdr = g_IModelInfo->GetStudiomodel(model);
-
-        if (!setup)
-        {
-            Setup(hdr);
-        }
-        if (!success)
-            return;
-
-        // ent->m_bBonesSetup = false;
-        const auto &bones = ent->hitboxes.GetBones();
-        DrawBoneList(bones, leg_r, 3, color);
-        DrawBoneList(bones, leg_l, 3, color);
-        DrawBoneList(bones, bottom, 3, color);
-        DrawBoneList(bones, spine, 7, color);
-        DrawBoneList(bones, arm_r, 3, color);
-        DrawBoneList(bones, arm_l, 3, color);
-        DrawBoneList(bones, up, 3, color);
-        /*for (int i = 0; i < hdr->numbones; i++) {
-            const auto& bone = ent->GetBones()[i];
-            Vector pos(bone[0][3], bone[1][3], bone[2][3]);
-            //pos += orig;
-            Vector screen;
-            if (draw::WorldToScreen(pos, screen)) {
-                if (hdr->pBone(i)->pszName()) {
-                    draw::FString(fonts::ESP, screen.x, screen.y, fg, 2, "%s
-        [%d]", hdr->pBone(i)->pszName(), i); } else draw::FString(fonts::ESP,
-        screen.x, screen.y, fg, 2, "%d", i);
-            }
-        }*/
-    }
+public:
+    void Setup(const studiohdr_t *hdr);
+    void _FASTCALL DrawBoneList(const matrix3x4_t *bones, int *in, int size, const rgba_t &color);
+    void _FASTCALL Draw(CachedEntity *ent, const rgba_t &color);
 };
+
+void bonelist_s::Setup(const studiohdr_t *hdr)
+{
+    if (!hdr)
+    {
+        setup   = false;
+        success = false;
+        return;
+    }
+    for (int i = 0; i < hdr->numbones; ++i)
+        bones.emplace(std::make_pair(std::string(hdr->pBone(i)->pszName()), i));
+    for (int i = 0; i < 7; ++i)
+        spine[i] = bones.at(bonenames_spine[i]);
+    for (int i = 0; i < 3; ++i)
+    {
+        arm_l[i]  = bones.at(bonenames_arm_l[i]);
+        up[i]     = bones.at(bonenames_up[i]);
+        arm_r[i]  = bones.at(bonenames_arm_r[i]);
+        bottom[i] = bones.at(bonenames_bottom[i]);
+        leg_l[i]  = bones.at(bonenames_leg_l[i]);
+        leg_r[i]  = bones.at(bonenames_leg_r[i]);
+    }
+
+    success = true;
+    setup   = true;
+}
+
+void _FASTCALL bonelist_s::DrawBoneList(const matrix3x4_t *bones, int *in, int size, const rgba_t &color)
+{
+    Vector last_screen;
+    Vector current_screen;
+    for (int i = 0; i < size; ++i)
+    {
+        const auto &bone = bones[in[i]];
+        Vector position(bone[0][3], bone[1][3], bone[2][3]);
+        if (!draw::WorldToScreen(position, current_screen))
+            return;
+        if (i > 0)
+            draw::Line(last_screen.x, last_screen.y, current_screen.x - last_screen.x, current_screen.y - last_screen.y, color, *bones_thickness);
+        last_screen = current_screen;
+    }
+}
+
+void _FASTCALL bonelist_s::Draw(CachedEntity *ent, const rgba_t &color)
+{
+    const model_t *model = RAW_ENT(ent)->GetModel();
+    if (!model)
+        return;
+
+    studiohdr_t *hdr = g_IModelInfo->GetStudiomodel(model);
+
+    if (!setup)
+        Setup(hdr);
+    if (!success)
+        return;
+    const auto &bones = ent->hitboxes.GetBones();
+    DrawBoneList(bones, leg_r, 3, color);
+    DrawBoneList(bones, leg_l, 3, color);
+    DrawBoneList(bones, bottom, 3, color);
+    DrawBoneList(bones, spine, 7, color);
+    DrawBoneList(bones, arm_r, 3, color);
+    DrawBoneList(bones, arm_l, 3, color);
+    DrawBoneList(bones, up, 3, color);
+}
 
 // These are strings that never change and should only be constructed once
 const std::string hoovy_str                = "Hoovy";
@@ -334,11 +305,8 @@ static void Draw()
     if (!enable)
         return;
     PROF_SECTION(DRAW_ESP_PERFORMANCE);
-    std::lock_guard<std::mutex> esp_lock(threadsafe_mutex);
     for (auto &i : entities_need_repaint)
-    {
         ProcessEntityPT(ENTITY(i.first));
-    }
 }
 
 // Function called on create move
@@ -348,9 +316,10 @@ static void cm()
     if (!*enable)
         return;
     if (CE_BAD(LOCAL_E))
+    {
+        data.clear();
         return;
-    // Something
-    std::lock_guard<std::mutex> esp_lock(threadsafe_mutex);
+    }
 
     // Update entites every 1/5s
     const bool entity_tick = g_GlobalVars->tickcount % TIME_TO_TICKS(0.20f) == 0;
@@ -358,8 +327,6 @@ static void cm()
     ResetEntityStrings(entity_tick); // Clear any strings entities have
     entities_need_repaint.clear();   // Clear data on entities that need redraw
     int max_clients          = g_GlobalVars->maxClients;
-    int limit                = HIGHEST_ENTITY;
-    bool run_all_ents        = false;
     const bool vischeck_tick = g_GlobalVars->tickcount % TIME_TO_TICKS(0.50f) == 0;
     // If not using any other special esp, we lower the min to the max
     // clients
@@ -371,31 +338,18 @@ static void cm()
         { // Prof section ends when out of scope, these brackets here.
             PROF_SECTION(CM_ESP_EntityLoop);
             // Loop through entities
-            for (int i = 0; i <= max_clients; i++)
+            for (auto const &ent : entity_cache::player_cache)
             {
                 // Get an entity from the loop tick and process it
-                CachedEntity *ent = ENTITY(i);
-                if (CE_INVALID(ent) || !ent->m_bAlivePlayer())
-                    continue;
+                ProcessEntity(ent);
+                hitboxUpdate(ent);
 
-                bool player = i < max_clients;
-
-                if (player)
-                {
-                    ProcessEntity(ent);
-                    hitboxUpdate(ent);
-                }
-                else if (entity_tick)
-                {
-                    ProcessEntity(ent);
-                    hitboxUpdate(ent);
-                }
-
-                if (data[ent->m_IDX].needs_paint)
+                data.emplace(std::make_pair(ent, ESPData{}));
+                if (data[ent].needs_paint)
                 {
                     // Checking this every tick is a waste of nanoseconds
                     if (vischeck_tick && vischeck)
-                        data[ent->m_IDX].transparent = !ent->IsVisible();
+                        data[ent].transparent = !ent->IsVisible();
                     entities_need_repaint.push_back({ ent->m_IDX, ent->m_vecOrigin().DistToSqr(g_pLocalPlayer->v_Origin) });
                 }
             }
@@ -406,7 +360,7 @@ static void cm()
         { // Prof section ends when out of scope, these brackets here.
             PROF_SECTION(CM_ESP_EntityLoop);
             // Loop through entities
-            for (auto &ent_index : entity_cache::valid_ents)
+            for (auto const &ent_index : entity_cache::valid_ents)
             {
                 // Get an entity from the loop tick and process it
                 if (!ent_index->m_bAlivePlayer())
@@ -424,12 +378,12 @@ static void cm()
                     ProcessEntity(ent_index);
                     hitboxUpdate(ent_index);
                 }
-
-                if (data[ent_index->m_IDX].needs_paint)
+                data.emplace(std::make_pair(ent_index, ESPData{}));
+                if (data[ent_index].needs_paint)
                 {
                     // Checking this every tick is a waste of nanoseconds
                     if (vischeck_tick && vischeck)
-                        data[ent_index->m_IDX].transparent = !ent_index->IsVisible();
+                        data[ent_index].transparent = !ent_index->IsVisible();
                     entities_need_repaint.push_back({ ent_index->m_IDX, ent_index->m_vecOrigin().DistToSqr(g_pLocalPlayer->v_Origin) });
                 }
             }
@@ -469,6 +423,336 @@ void _FASTCALL hitboxUpdate(CachedEntity *ent)
         }
     }
 }
+void _FASTCALL Sightlines(CachedEntity *ent, rgba_t &fg)
+{
+
+    // Logic for using the enum to sort out snipers
+    if (((int) sightlines == 2 || ((int) sightlines == 1 && CE_INT(ent, netvar.iClass) == tf_sniper)) && CE_GOOD(ent) && ent->hitboxes.GetHitbox(0))
+    {
+        PROF_SECTION(PT_esp_sightlines);
+
+        // Get players angle and head position
+        Vector &eye_angles = NET_VECTOR(RAW_ENT(ent), netvar.m_angEyeAngles);
+        Vector eye_position;
+        eye_position = ent->hitboxes.GetHitbox(0)->center;
+
+        // Main ray tracing area
+        float sy         = sinf(DEG2RAD(eye_angles.y)); // yaw
+        float cy         = cosf(DEG2RAD(eye_angles.y));
+        float sp         = sinf(DEG2RAD(eye_angles.x)); // pitch
+        float cp         = cosf(DEG2RAD(eye_angles.x));
+        Vector forward_t = Vector(cp * cy, cp * sy, -sp);
+        // We dont want the sightlines endpoint to go behind us because the
+        // world to screen check will fail, but keep it at most 4096
+        Vector forward = forward_t * 4096.0F + eye_position;
+        Ray_t ray;
+        ray.Init(eye_position, forward);
+        trace_t trace;
+        g_ITrace->TraceRay(ray, MASK_SOLID, &trace::filter_no_player, &trace);
+
+        // Screen vectors
+        Vector scn1, scn2;
+
+        // Status vars
+        bool found_scn2 = true;
+
+        // Get end point on screen
+        if (!draw::WorldToScreen(trace.endpos, scn2))
+        {
+            // Set status
+            found_scn2 = false;
+            // Get the end distance from the trace
+            float end_distance = trace.endpos.DistTo(eye_position);
+
+            // Loop and look back until we have a vector on screen
+            for (int i = 1; i < 500; ++i)
+            {
+                // Subtract 40 multiplyed by the tick from the end distance
+                // and use that as our length to check
+                Vector end_vector = forward_t * (end_distance - (10 * i)) + eye_position;
+                if (end_vector.DistTo(eye_position) < 1)
+                    break;
+                if (draw::WorldToScreen(end_vector, scn2))
+                {
+                    found_scn2 = true;
+                    break;
+                }
+            }
+        }
+
+        if (found_scn2)
+        {
+            // Set status
+            bool found_scn1 = true;
+
+            // If we dont have a vector on screen, attempt to find one
+            if (!draw::WorldToScreen(eye_position, scn1))
+            {
+                // Set status
+                found_scn1 = false;
+
+                // Loop and look back untill we have a vector on screen
+                for (int i = 1; i < 500; ++i)
+                {
+                    // Multiply starting distance by 15, multiplyed by the
+                    // loop tick
+                    Vector start_vector = forward_t * (10 * i) + eye_position;
+                    // We dont want it to go too far
+                    if (start_vector.DistTo(trace.endpos) < 1)
+                        break;
+                    // Check if we have a vector on screen, if we do then we
+                    // set our status
+                    if (draw::WorldToScreen(start_vector, scn1))
+                    {
+                        found_scn1 = true;
+                        break;
+                    }
+                }
+            }
+            // We have both vectors, draw
+            if (found_scn1)
+            {
+                draw::Line(scn1.x, scn1.y, scn2.x - scn1.x, scn2.y - scn1.y, fg, 0.5f);
+            }
+        }
+    }
+}
+void _FASTCALL Healthbar(EntityType &type, int &classid, rgba_t &fg, ESPData &ent_data, CachedEntity *ent)
+{
+
+    if (type == ENTITY_PLAYER || type == ENTITY_BUILDING)
+    {
+        // Get collidable from the cache
+        if (GetCollide(ent))
+        {
+
+            // Pull the cached collide info
+            int max_x = ent_data.collide_max.x;
+            int max_y = ent_data.collide_max.y;
+            int min_x = ent_data.collide_min.x;
+            int min_y = ent_data.collide_min.y;
+
+            // Get health values
+            int health    = 0;
+            int healthmax = 0;
+            switch (type)
+            {
+            case ENTITY_PLAYER:
+                health    = g_pPlayerResource->GetHealth(ent);
+                healthmax = g_pPlayerResource->GetMaxHealth(ent);
+                break;
+            case ENTITY_BUILDING:
+                health    = CE_INT(ent, netvar.iBuildingHealth);
+                healthmax = CE_INT(ent, netvar.iBuildingMaxHealth);
+                break;
+            }
+
+            // Get Colors
+            rgba_t hp     = colors::Transparent(colors::Health(health, healthmax), fg.a);
+            rgba_t border = ((classid == RCC_PLAYER) && IsPlayerInvisible(ent)) ? colors::FromRGBA8(160, 160, 160, fg.a * 255.0f) : colors::Transparent(colors::black, fg.a);
+            // Get bar width and height
+            int hbw = (max_x - min_x - 1) * std::min((float) health / (float) healthmax, 1.0f);
+            int hbh = (max_y - min_y - 2) * std::min((float) health / (float) healthmax, 1.0f);
+
+            // Top horizontal health bar
+            if (*healthbar == 1)
+            {
+                draw::RectangleOutlined(min_x, min_y - 6, max_x - min_x + 1, 7, border, 0.5f);
+                draw::Rectangle(min_x + hbw, min_y - 5, -hbw, 5, hp);
+            }
+            // Bottom horizontal health bar
+            else if (*healthbar == 2)
+            {
+                draw::RectangleOutlined(min_x, max_y, max_x - min_x + 1, 7, border, 0.5f);
+                draw::Rectangle(min_x + hbw, max_y + 1, -hbw, 5, hp);
+            }
+            // Vertical health bar
+            else if (*healthbar == 3)
+            {
+                draw::RectangleOutlined(min_x - 7, min_y, 7, max_y - min_y, border, 0.5f);
+                draw::Rectangle(min_x - 6, max_y - hbh - 1, 5, hbh, hp);
+            }
+        }
+    }
+}
+void DrawStrings(EntityType &type, bool &transparent, Vector &draw_point, ESPData &ent_data, CachedEntity *ent)
+{
+    PROF_SECTION(PT_esp_drawstrings);
+
+    // Create our initial point at the center of the entity
+
+    bool origin_is_zero = true;
+
+    // Only get collidable for players and buildings
+    if (type == ENTITY_PLAYER || type == ENTITY_BUILDING)
+    {
+
+        // Get collidable from the cache
+        if (GetCollide(ent))
+        {
+
+            // Origin could change so we set to false
+            origin_is_zero = false;
+
+            // Pull the cached collide info
+            int max_x = ent_data.collide_max.x;
+            int max_y = ent_data.collide_max.y;
+            int min_x = ent_data.collide_min.x;
+            int min_y = ent_data.collide_min.y;
+
+            // Change the position of the draw point depending on the user
+            // settings
+            switch ((int) esp_text_position)
+            {
+            case 0:
+            { // TOP RIGHT
+                draw_point = Vector(max_x + 2, min_y, 0);
+            }
+            break;
+            case 1:
+            { // BOTTOM RIGHT
+                draw_point = Vector(max_x + 2, max_y - data.at(ent).string_count * 16, 0);
+            }
+            break;
+            case 2:
+            {                          // CENTER
+                origin_is_zero = true; // origin is still zero so we set to true
+            }
+            break;
+            case 3:
+            { // ABOVE CENTER
+                draw_point = Vector((min_x + max_x) / 2.0f, min_y - data.at(ent).string_count * 16, 0);
+            }
+            break;
+            case 4:
+            { // BELOW
+                draw_point = Vector((min_x + max_x) / 2.0f, max_y, 0);
+            }
+            break;
+            case 5:
+            { // ABOVE LEFT
+                draw_point = Vector(min_x + 2, min_y - data.at(ent).string_count * 16, 0);
+            }
+            break;
+            case 6:
+            { // ABOVE RIGHT
+                draw_point = Vector(max_x + 2, min_y - data.at(ent).string_count * 16, 0);
+            }
+            }
+        }
+    }
+
+    // Loop through strings
+    for (int j = 0; j < ent_data.string_count; j++)
+    {
+
+        // Pull string from the entity's cached string array
+        const ESPString &string = ent_data.strings[j];
+
+        // If string has a color assined to it, apply that otherwise use
+        // entities color
+        rgba_t color = string.color ? string.color : ent_data.color;
+        if (transparent)
+            color = colors::Transparent(color); // Apply transparency if needed
+
+        // If the origin is centered, we use one method. if not, the other
+        if (!origin_is_zero || true)
+        {
+            float draw_pointx_tmp = draw_point.x;
+            // Above/Below text should be centered
+            if (*esp_text_position == 3 || *esp_text_position == 4)
+            {
+                float w, h;
+                fonts::esp->stringSize(string.data, &w, &h);
+                draw_pointx_tmp -= w / 2.0f;
+            }
+            draw::String(draw_pointx_tmp, draw_point.y, color, string.data.c_str(), *fonts::esp);
+        }
+
+        // Add to the y due to their being text in that spot
+        draw_point.y += /*((int)fonts::font_main->height)*/ 15 - 1;
+    }
+}
+void _FASTCALL BoxEsp(EntityType &type, bool &transparent, rgba_t &fg, CachedEntity *ent)
+{
+    switch (type)
+    {
+    case ENTITY_PLAYER:
+        if (!fg)
+            fg = colors::EntityF(ent);
+        if (transparent)
+            fg = colors::Transparent(fg);
+        if (RAW_ENT(ent)->IsDormant())
+        {
+            fg.r *= 0.75f;
+            fg.g *= 0.75f;
+            fg.b *= 0.75f;
+        }
+        if (!box_3d_player && box_esp)
+            DrawBox(ent, fg);
+        else if (box_3d_player)
+            Draw3DBox(ent, fg);
+        break;
+    case ENTITY_BUILDING:
+        if (CE_INT(ent, netvar.iTeamNum) == g_pLocalPlayer->team && !team_buildings)
+            break;
+        if (!fg)
+            fg = colors::EntityF(ent);
+        if (transparent)
+            fg = colors::Transparent(fg);
+        if (RAW_ENT(ent)->IsDormant())
+        {
+            fg.r *= 0.75f;
+            fg.g *= 0.75f;
+            fg.b *= 0.75f;
+        }
+        // Draw exit arrow
+        // YawToExit is 0.0f on exit and on newly placed still disabled entrances
+        // m_iState is 0 when the TP is disabled
+        if (ent->m_iClassID() == CL_CLASS(CObjectTeleporter) && CE_FLOAT(ent, netvar.m_flTeleYawToExit) == 0.0f && CE_INT(ent, netvar.m_iTeleState) > 1)
+        {
+            float sin_a, cos_a;
+            // for some reason vAngRotation yaw differs from exit direction, unsure why
+            SinCos(DEG2RAD(CE_VECTOR(ent, netvar.m_angRotation).y - 90.0f), &sin_a, &cos_a);
+
+            // pseudo used to rotate properly
+            // screen is passed to filledpolygon
+            Vector pseudo[3];
+            Vector screen[3];
+
+            // 24 = teleporter width and height
+            // 16 = arrow size
+            pseudo[0].x = 0.0f; // Undefined behaviour bruh
+            pseudo[0].y = 16.0f + 24.0f;
+            pseudo[1].x = -16.0f;
+            pseudo[1].y = 24.0f;
+            pseudo[2].x = 16.0f;
+            pseudo[2].y = 24.0f;
+
+            // pass vector, get vector
+            // 12 is teleporter height, arrow is 12 HU off the ground
+            // sin and cos are already passed in captures
+            auto rotateVector = [sin_a = sin_a, cos_a = cos_a](Vector &in) { return Vector(in.x * cos_a - in.y * sin_a, in.x * sin_a + in.y * cos_a, 12.0f); };
+
+            // fail check
+            bool visible = true;
+
+            // rotate, add vecorigin AND check worldtoscreen at the same time in single loop
+            for (int p = 0; p < 3; p++)
+                if (!(visible = draw::WorldToScreen(rotateVector(pseudo[p]) + ent->m_vecOrigin(), screen[p])))
+                    break;
+
+            // if visible, pass it and draw the whole thing, ez pz
+            if (visible)
+                draw::Triangle(screen[0].x, screen[0].y, screen[1].x, screen[1].y, screen[2].x, screen[2].y, fg);
+        }
+        if (!box_3d_building && box_esp)
+            DrawBox(ent, fg);
+        else if (box_3d_building)
+            Draw3DBox(ent, fg);
+        break;
+    }
+}
 // Used when processing entitys with cached data from createmove in draw
 void _FASTCALL ProcessEntityPT(CachedEntity *ent)
 {
@@ -489,7 +773,7 @@ void _FASTCALL ProcessEntityPT(CachedEntity *ent)
     int classid     = ent->m_iClassID();
     EntityType type = ent->m_Type();
     // Grab esp data
-    ESPData &ent_data = data[ent->m_IDX];
+    ESPData &ent_data = data[ent];
 
     // Get color of entity
     // TODO, check if we can move this after world to screen check
@@ -513,98 +797,7 @@ void _FASTCALL ProcessEntityPT(CachedEntity *ent)
 
     // Sightline esp
     if (sightlines && type == ENTITY_PLAYER)
-    {
-        // Logic for using the enum to sort out snipers
-        if (((int) sightlines == 2 || ((int) sightlines == 1 && CE_INT(ent, netvar.iClass) == tf_sniper)) && CE_GOOD(ent) && ent->hitboxes.GetHitbox(0))
-        {
-            PROF_SECTION(PT_esp_sightlines);
-
-            // Get players angle and head position
-            Vector &eye_angles = NET_VECTOR(RAW_ENT(ent), netvar.m_angEyeAngles);
-            Vector eye_position;
-            eye_position = ent->hitboxes.GetHitbox(0)->center;
-
-            // Main ray tracing area
-            float sy         = sinf(DEG2RAD(eye_angles.y)); // yaw
-            float cy         = cosf(DEG2RAD(eye_angles.y));
-            float sp         = sinf(DEG2RAD(eye_angles.x)); // pitch
-            float cp         = cosf(DEG2RAD(eye_angles.x));
-            Vector forward_t = Vector(cp * cy, cp * sy, -sp);
-            // We dont want the sightlines endpoint to go behind us because the
-            // world to screen check will fail, but keep it at most 4096
-            Vector forward = forward_t * 4096.0F + eye_position;
-            Ray_t ray;
-            ray.Init(eye_position, forward);
-            trace_t trace;
-            g_ITrace->TraceRay(ray, MASK_SOLID, &trace::filter_no_player, &trace);
-
-            // Screen vectors
-            Vector scn1, scn2;
-
-            // Status vars
-            bool found_scn2 = true;
-
-            // Get end point on screen
-            if (!draw::WorldToScreen(trace.endpos, scn2))
-            {
-                // Set status
-                found_scn2 = false;
-                // Get the end distance from the trace
-                float end_distance = trace.endpos.DistTo(eye_position);
-
-                // Loop and look back until we have a vector on screen
-                for (int i = 1; i < 500; i++)
-                {
-                    // Subtract 40 multiplyed by the tick from the end distance
-                    // and use that as our length to check
-                    Vector end_vector = forward_t * (end_distance - (10 * i)) + eye_position;
-                    if (end_vector.DistTo(eye_position) < 1)
-                        break;
-                    if (draw::WorldToScreen(end_vector, scn2))
-                    {
-                        found_scn2 = true;
-                        break;
-                    }
-                }
-            }
-
-            if (found_scn2)
-            {
-                // Set status
-                bool found_scn1 = true;
-
-                // If we dont have a vector on screen, attempt to find one
-                if (!draw::WorldToScreen(eye_position, scn1))
-                {
-                    // Set status
-                    found_scn1 = false;
-
-                    // Loop and look back untill we have a vector on screen
-                    for (int i = 1; i < 500; i++)
-                    {
-                        // Multiply starting distance by 15, multiplyed by the
-                        // loop tick
-                        Vector start_vector = forward_t * (10 * i) + eye_position;
-                        // We dont want it to go too far
-                        if (start_vector.DistTo(trace.endpos) < 1)
-                            break;
-                        // Check if we have a vector on screen, if we do then we
-                        // set our status
-                        if (draw::WorldToScreen(start_vector, scn1))
-                        {
-                            found_scn1 = true;
-                            break;
-                        }
-                    }
-                }
-                // We have both vectors, draw
-                if (found_scn1)
-                {
-                    draw::Line(scn1.x, scn1.y, scn2.x - scn1.x, scn2.y - scn1.y, fg, 0.5f);
-                }
-            }
-        }
-    }
+        Sightlines(ent, fg);
 
     static Vector screen;
     if (!draw::EntityCenterToScreen(ent, screen))
@@ -618,85 +811,7 @@ void _FASTCALL ProcessEntityPT(CachedEntity *ent)
 
     // Box esp
     if (box_esp || box_3d_player || box_3d_building)
-    {
-        switch (type)
-        {
-        case ENTITY_PLAYER:
-            if (!fg)
-                fg = colors::EntityF(ent);
-            if (transparent)
-                fg = colors::Transparent(fg);
-            if (RAW_ENT(ent)->IsDormant())
-            {
-                fg.r *= 0.75f;
-                fg.g *= 0.75f;
-                fg.b *= 0.75f;
-            }
-            if (!box_3d_player && box_esp)
-                DrawBox(ent, fg);
-            else if (box_3d_player)
-                Draw3DBox(ent, fg);
-            break;
-        case ENTITY_BUILDING:
-            if (CE_INT(ent, netvar.iTeamNum) == g_pLocalPlayer->team && !team_buildings)
-                break;
-            if (!fg)
-                fg = colors::EntityF(ent);
-            if (transparent)
-                fg = colors::Transparent(fg);
-            if (RAW_ENT(ent)->IsDormant())
-            {
-                fg.r *= 0.75f;
-                fg.g *= 0.75f;
-                fg.b *= 0.75f;
-            }
-            // Draw exit arrow
-            // YawToExit is 0.0f on exit and on newly placed still disabled entrances
-            // m_iState is 0 when the TP is disabled
-            if (ent->m_iClassID() == CL_CLASS(CObjectTeleporter) && CE_FLOAT(ent, netvar.m_flTeleYawToExit) == 0.0f && CE_INT(ent, netvar.m_iTeleState) > 1)
-            {
-                float sin_a, cos_a;
-                // for some reason vAngRotation yaw differs from exit direction, unsure why
-                SinCos(DEG2RAD(CE_VECTOR(ent, netvar.m_angRotation).y - 90.0f), &sin_a, &cos_a);
-
-                // pseudo used to rotate properly
-                // screen is passed to filledpolygon
-                Vector pseudo[3];
-                Vector screen[3];
-
-                // 24 = teleporter width and height
-                // 16 = arrow size
-                pseudo[0].x = 0.0f; // Undefined behaviour bruh
-                pseudo[0].y = 16.0f + 24.0f;
-                pseudo[1].x = -16.0f;
-                pseudo[1].y = 24.0f;
-                pseudo[2].x = 16.0f;
-                pseudo[2].y = 24.0f;
-
-                // pass vector, get vector
-                // 12 is teleporter height, arrow is 12 HU off the ground
-                // sin and cos are already passed in captures
-                auto rotateVector = [sin_a = sin_a, cos_a = cos_a](Vector &in) { return Vector(in.x * cos_a - in.y * sin_a, in.x * sin_a + in.y * cos_a, 12.0f); };
-
-                // fail check
-                bool visible = true;
-
-                // rotate, add vecorigin AND check worldtoscreen at the same time in single loop
-                for (int p = 0; p < 3; p++)
-                    if (!(visible = draw::WorldToScreen(rotateVector(pseudo[p]) + ent->m_vecOrigin(), screen[p])))
-                        break;
-
-                // if visible, pass it and draw the whole thing, ez pz
-                if (visible)
-                    draw::Triangle(screen[0].x, screen[0].y, screen[1].x, screen[1].y, screen[2].x, screen[2].y, fg);
-            }
-            if (!box_3d_building && box_esp)
-                DrawBox(ent, fg);
-            else if (box_3d_building)
-                Draw3DBox(ent, fg);
-            break;
-        }
-    }
+        BoxEsp(type, transparent, fg, ent);
 
     if (draw_bones)
     {
@@ -706,7 +821,7 @@ void _FASTCALL ProcessEntityPT(CachedEntity *ent)
         if (transparent)
             bone_color = colors::Transparent(bone_color);
 
-        bonelist_s bl;
+        static bonelist_s bl;
         if (!CE_INVALID(ent) && ent->m_bAlivePlayer() && !RAW_ENT(ent)->IsDormant())
         {
             if (bones_color)
@@ -718,220 +833,12 @@ void _FASTCALL ProcessEntityPT(CachedEntity *ent)
 
     // Health bar
     if (*healthbar != 0)
-    {
-
-        // We only want health bars on players and buildings
-        if (type == ENTITY_PLAYER || type == ENTITY_BUILDING)
-        {
-
-            // Get collidable from the cache
-            if (GetCollide(ent))
-            {
-
-                // Pull the cached collide info
-                int max_x = ent_data.collide_max.x;
-                int max_y = ent_data.collide_max.y;
-                int min_x = ent_data.collide_min.x;
-                int min_y = ent_data.collide_min.y;
-
-                // Get health values
-                int health    = 0;
-                int healthmax = 0;
-                switch (type)
-                {
-                case ENTITY_PLAYER:
-                    health    = g_pPlayerResource->GetHealth(ent);
-                    healthmax = g_pPlayerResource->GetMaxHealth(ent);
-                    break;
-                case ENTITY_BUILDING:
-                    health    = CE_INT(ent, netvar.iBuildingHealth);
-                    healthmax = CE_INT(ent, netvar.iBuildingMaxHealth);
-                    break;
-                }
-
-                // Get Colors
-                rgba_t hp     = colors::Transparent(colors::Health(health, healthmax), fg.a);
-                rgba_t border = ((classid == RCC_PLAYER) && IsPlayerInvisible(ent)) ? colors::FromRGBA8(160, 160, 160, fg.a * 255.0f) : colors::Transparent(colors::black, fg.a);
-                // Get bar width and height
-                int hbw = (max_x - min_x - 1) * std::min((float) health / (float) healthmax, 1.0f);
-                int hbh = (max_y - min_y - 2) * std::min((float) health / (float) healthmax, 1.0f);
-
-                // Top horizontal health bar
-                if (*healthbar == 1)
-                {
-                    draw::RectangleOutlined(min_x, min_y - 6, max_x - min_x + 1, 7, border, 0.5f);
-                    draw::Rectangle(min_x + hbw, min_y - 5, -hbw, 5, hp);
-                }
-                // Bottom horizontal health bar
-                else if (*healthbar == 2)
-                {
-                    draw::RectangleOutlined(min_x, max_y, max_x - min_x + 1, 7, border, 0.5f);
-                    draw::Rectangle(min_x + hbw, max_y + 1, -hbw, 5, hp);
-                }
-                // Vertical health bar
-                else if (*healthbar == 3)
-                {
-                    draw::RectangleOutlined(min_x - 7, min_y, 7, max_y - min_y, border, 0.5f);
-                    draw::Rectangle(min_x - 6, max_y - hbh - 1, 5, hbh, hp);
-                }
-            }
-        }
-    }
+        Healthbar(type, classid, fg, ent_data, ent);
+    // We only want health bars on players and buildings
 
     // Check if entity has strings to draw
     if (ent_data.string_count)
-    {
-        PROF_SECTION(PT_esp_drawstrings);
-
-        // Create our initial point at the center of the entity
-        Vector draw_point   = screen;
-        bool origin_is_zero = true;
-
-        // Only get collidable for players and buildings
-        if (type == ENTITY_PLAYER || type == ENTITY_BUILDING)
-        {
-
-            // Get collidable from the cache
-            if (GetCollide(ent))
-            {
-
-                // Origin could change so we set to false
-                origin_is_zero = false;
-
-                // Pull the cached collide info
-                int max_x = ent_data.collide_max.x;
-                int max_y = ent_data.collide_max.y;
-                int min_x = ent_data.collide_min.x;
-                int min_y = ent_data.collide_min.y;
-
-                // Change the position of the draw point depending on the user
-                // settings
-                switch ((int) esp_text_position)
-                {
-                case 0:
-                { // TOP RIGHT
-                    draw_point = Vector(max_x + 2, min_y, 0);
-                }
-                break;
-                case 1:
-                { // BOTTOM RIGHT
-                    draw_point = Vector(max_x + 2, max_y - data.at(ent->m_IDX).string_count * 16, 0);
-                }
-                break;
-                case 2:
-                {                          // CENTER
-                    origin_is_zero = true; // origin is still zero so we set to true
-                }
-                break;
-                case 3:
-                { // ABOVE CENTER
-                    draw_point = Vector((min_x + max_x) / 2.0f, min_y - data.at(ent->m_IDX).string_count * 16, 0);
-                }
-                break;
-                case 4:
-                { // BELOW
-                    draw_point = Vector((min_x + max_x) / 2.0f, max_y, 0);
-                }
-                break;
-                case 5:
-                { // ABOVE LEFT
-                    draw_point = Vector(min_x + 2, min_y - data.at(ent->m_IDX).string_count * 16, 0);
-                }
-                break;
-                case 6:
-                { // ABOVE RIGHT
-                    draw_point = Vector(max_x + 2, min_y - data.at(ent->m_IDX).string_count * 16, 0);
-                }
-                }
-            }
-        }
-
-        // Loop through strings
-        for (int j = 0; j < ent_data.string_count; j++)
-        {
-
-            // Pull string from the entity's cached string array
-            const ESPString &string = ent_data.strings[j];
-
-            // If string has a color assined to it, apply that otherwise use
-            // entities color
-            rgba_t color = string.color ? string.color : ent_data.color;
-            if (transparent)
-                color = colors::Transparent(color); // Apply transparency if needed
-
-            // If the origin is centered, we use one method. if not, the other
-            if (!origin_is_zero || true)
-            {
-                float draw_pointx_tmp = draw_point.x;
-                // Above/Below text should be centered
-                if (*esp_text_position == 3 || *esp_text_position == 4)
-                {
-                    float w, h;
-                    fonts::esp->stringSize(string.data, &w, &h);
-                    draw_pointx_tmp -= w / 2.0f;
-                }
-                draw::String(draw_pointx_tmp, draw_point.y, color, string.data.c_str(), *fonts::esp);
-            }
-            else
-            { /*
-          int size_x;
-          FTGL_StringLength(string.data, fonts::font_main, &size_x);
-          FTGL_Draw(string.data, draw_point.x - size_x / 2, draw_point.y,
-          fonts::font_main, color);
-      */
-            }
-
-            // Add to the y due to their being text in that spot
-            draw_point.y += /*((int)fonts::font_main->height)*/ 15 - 1;
-        }
-    }
-
-    // TODO Add Rotation matix
-    // TODO Currently crashes, needs null check somewhere
-    // Draw Hitboxes
-    /*if (draw_hitbox && type == ENTITY_PLAYER) {
-        PROF_SECTION(PT_esp_drawhitbboxes);
-
-        // Loop through hitboxes
-        for (int i = 0; i <= 17; i++) { // I should probs get how many hitboxes
-    instead of using a fixed number...
-
-            // Get a hitbox from the entity
-            hitbox_cache::CachedHitbox* hb = ent->hitboxes.GetHitbox(i);
-
-            // Create more points from min + max
-            Vector box_points[8];
-            Vector vec_tmp;
-            for (int ii = 0; ii <= 8; ii++) { // 8 points to the box
-
-                // logic le paste from sdk
-                vec_tmp[0] = ( ii & 0x1 ) ? hb->max[0] : hb->min[0];
-                vec_tmp[1] = ( ii & 0x2 ) ? hb->max[1] : hb->min[1];
-                vec_tmp[2] = ( ii & 0x4 ) ? hb->max[2] : hb->min[2];
-
-                // save to points array
-                box_points[ii] = vec_tmp;
-            }
-
-            // Draw box from points
-            // Draws a point to every other point. Ineffient, use now fix
-    later... Vector scn1, scn2; // to screen for (int ii = 0; ii < 8; ii++) {
-
-                // Get first point
-                if (!draw::WorldToScreen(box_points[ii], scn1)) continue;
-
-                for (int iii = 0; iii < 8; iii++) {
-
-                    // Get second point
-                    if (!draw::WorldToScreen(box_points[iii], scn2)) continue;
-
-                    // Draw between points
-                    draw_api::Line(scn1.x, scn1.y, scn2.x - scn1.x, scn2.y -
-    scn1.y, fg);
-                }
-            }
-        }
-    }*/
+        DrawStrings(type, transparent, screen, ent_data, ent);
 }
 
 // Used to process entities from CreateMove
@@ -971,7 +878,7 @@ void _FASTCALL ProcessEntity(CachedEntity *ent)
     }
 
     // Get esp data from current ent
-    ESPData &espdata = data[ent->m_IDX];
+    ESPData &espdata = data[ent];
 
     // Projectile esp
     if (ent->m_Type() == ENTITY_PROJECTILE && proj_esp && (ent->m_bEnemy() || (teammates && !proj_enemy)))
@@ -1016,44 +923,6 @@ void _FASTCALL ProcessEntity(CachedEntity *ent)
             if ((int) proj_arrows != 2 || ent->m_bCritProjectile())
             {
                 AddEntityString(ent, arrow_str);
-            }
-        }
-    }
-
-    // Hl2DM dropped item esp
-    IF_GAME(IsHL2DM())
-    {
-        if (item_esp && item_dropped_weapons)
-        {
-            if (CE_BYTE(ent, netvar.hOwner) == (unsigned char) -1)
-            {
-                int string_count_backup = data[ent->m_IDX].string_count;
-                if (classid == CL_CLASS(CWeapon_SLAM))
-                    AddEntityString(ent, slam_str);
-                else if (classid == CL_CLASS(CWeapon357))
-                    AddEntityString(ent, point357_str);
-                else if (classid == CL_CLASS(CWeaponAR2))
-                    AddEntityString(ent, ar2_str);
-                else if (classid == CL_CLASS(CWeaponAlyxGun))
-                    AddEntityString(ent, alyx_gun_str);
-                else if (classid == CL_CLASS(CWeaponAnnabelle))
-                    AddEntityString(ent, annabelle_str);
-                else if (classid == CL_CLASS(CWeaponBinoculars))
-                    AddEntityString(ent, binoculars_str);
-                else if (classid == CL_CLASS(CWeaponBugBait))
-                    AddEntityString(ent, bugbait_str);
-                else if (classid == CL_CLASS(CWeaponCrossbow))
-                    AddEntityString(ent, crossbow_str);
-                else if (classid == CL_CLASS(CWeaponShotgun))
-                    AddEntityString(ent, shotgun_str);
-                else if (classid == CL_CLASS(CWeaponSMG1))
-                    AddEntityString(ent, smg_str);
-                else if (classid == CL_CLASS(CWeaponRPG))
-                    AddEntityString(ent, rpg_str);
-                /*if (string_count_backup != data[ent->m_IDX].string_count)
-                {
-                    SetEntityColor(ent, colors::yellow);
-                }*/
             }
         }
     }
@@ -1436,7 +1305,7 @@ void _FASTCALL ProcessEntity(CachedEntity *ent)
             // ipc bot esp
             if (show_bot_id && ipc::peer && ent != LOCAL_E)
             {
-                for (unsigned i = 0; i < cat_ipc::max_peers; i++)
+                for (unsigned i = 0; i < cat_ipc::max_peers; ++i)
                 {
                     if (!ipc::peer->memory->peer_data[i].free && ipc::peer->memory->peer_user_data[i].friendid == info.friendsID)
                     {
@@ -1461,7 +1330,7 @@ void _FASTCALL ProcessEntity(CachedEntity *ent)
                     if (CE_INT(ent, netvar.iClass) == tf_medic)
                     {
                         int *weapon_list = (int *) ((unsigned) (RAW_ENT(ent)) + netvar.hMyWeapons);
-                        for (int i = 0; weapon_list[i]; i++)
+                        for (int i = 0; weapon_list[i]; ++i)
                         {
                             int handle = weapon_list[i];
                             int eid    = HandleToIDX(handle);
@@ -1641,7 +1510,7 @@ void _FASTCALL Draw3DBox(CachedEntity *ent, const rgba_t &clr)
     corners[7] = mins + Vector(0, y, z);
 
     // Rotate the box and check if any point of the box isnt on the screen
-    for (int i = 0; i < 8; i++)
+    for (int i = 0; i < 8; ++i)
     {
         float yaw    = NET_VECTOR(RAW_ENT(ent), netvar.m_angEyeAngles).y;
         float s      = sinf(DEG2RAD(yaw));
@@ -1657,7 +1526,7 @@ void _FASTCALL Draw3DBox(CachedEntity *ent, const rgba_t &clr)
     }
     rgba_t draw_clr = clr;
     // Draw the actual box
-    for (int i = 1; i <= 4; i++)
+    for (int i = 1; i <= 4; ++i)
     {
         draw::Line((points[i - 1].x), (points[i - 1].y), (points[i % 4].x) - (points[i - 1].x), (points[i % 4].y) - (points[i - 1].y), draw_clr, 0.5f);
         draw::Line((points[i - 1].x), (points[i - 1].y), (points[i + 3].x) - (points[i - 1].x), (points[i + 3].y) - (points[i - 1].y), draw_clr, 0.5f);
@@ -1679,7 +1548,7 @@ void _FASTCALL DrawBox(CachedEntity *ent, const rgba_t &clr)
         return;
 
     // Pull the cached collide info
-    ESPData &ent_data = data[ent->m_IDX];
+    ESPData &ent_data = data[ent];
     int max_x         = ent_data.collide_max.x;
     int max_y         = ent_data.collide_max.y;
     int min_x         = ent_data.collide_min.x;
@@ -1746,7 +1615,7 @@ bool GetCollide(CachedEntity *ent)
         return false;
 
     // Grab esp data
-    ESPData &ent_data = data[ent->m_IDX];
+    ESPData &ent_data = data[ent];
 
     // If entity has cached collides, return it. Otherwise generate new bounds
     if (!ent_data.has_collide)
@@ -1794,7 +1663,7 @@ bool GetCollide(CachedEntity *ent)
         points_r[6] = mins + Vector(x, y, z);
         points_r[7] = mins + Vector(0, y, z);
 
-        for (int i = 0; i < 8; i++)
+        for (int i = 0; i < 8; ++i)
         {
             if (!draw::WorldToScreen(points_r[i], points[i]))
                 return false;
@@ -1805,7 +1674,7 @@ bool GetCollide(CachedEntity *ent)
         int max_y = -1;
         int min_x = 65536;
         int min_y = 65536;
-        for (int i = 0; i < 8; i++)
+        for (int i = 0; i < 8; ++i)
         {
             if (points[i].x > max_x)
                 max_x = points[i].x;
@@ -1836,7 +1705,7 @@ bool GetCollide(CachedEntity *ent)
 // Use to add a esp string to an entity
 void AddEntityString(CachedEntity *entity, const std::string &string, const rgba_t &color)
 {
-    ESPData &entity_data = data[entity->m_IDX];
+    ESPData &entity_data = data[entity];
     if (entity_data.string_count >= 15)
         return;
     entity_data.strings[entity_data.string_count].data  = string;
@@ -1849,16 +1718,16 @@ void AddEntityString(CachedEntity *entity, const std::string &string, const rgba
 void ResetEntityStrings(bool full_clear)
 {
     if (full_clear)
-        for (auto &i : data)
+        for (auto &[key, val] : data)
         {
-            i.string_count = 0;
-            i.color        = colors::empty;
-            i.needs_paint  = false;
+            val.string_count = 0;
+            val.color        = colors::empty;
+            val.needs_paint  = false;
         }
     else
-        for (std::size_t i = 0; i < g_GlobalVars->maxClients; ++i)
+        for (int i = 1; i < g_GlobalVars->maxClients; ++i)
         {
-            auto &element        = data[i];
+            auto &element        = data[ENTITY(i)];
             element.string_count = 0;
             element.color        = colors::empty;
             element.needs_paint  = false;
@@ -1870,7 +1739,7 @@ void SetEntityColor(CachedEntity *entity, const rgba_t &color)
 {
     if (entity->m_IDX > 2047 || entity->m_IDX < 0)
         return;
-    data[entity->m_IDX].color = color;
+    data[entity].color = color;
 }
 
 static InitRoutine init(

--- a/src/hacks/ExplosionCircles.cpp
+++ b/src/hacks/ExplosionCircles.cpp
@@ -35,7 +35,7 @@ void draw_sphere(Vector center, double r, std::vector<Vector> &spherePoints)
         spherePoints.emplace_back(center.x, center.y, center.z - r);
         int vecsize = spherePoints.size();
         Vector prev = spherePoints.front();
-        for (int i = 1; i < vecsize; i++)
+        for (int i = 1; i < vecsize; ++i)
         {
             if (draw::WorldToScreen(prev, screen) && draw::WorldToScreen(spherePoints[i], screen2))
             {
@@ -55,7 +55,7 @@ void draw()
         return;
     std::vector<Vector> points;
     Vector screen;
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         if (!ent->m_bEnemy())
             continue;

--- a/src/hacks/FollowBot.cpp
+++ b/src/hacks/FollowBot.cpp
@@ -64,9 +64,9 @@ static CatCommand follow_steam("fb_steam", "Follow Steam Id",
 static CatCommand steam_debug("debug_steamid", "Print steamids",
                               []()
                               {
-                                  for (int i = 0; i <= g_IEngine->GetMaxClients(); i++)
+                                  for (auto const &ent: entity_cache::player_cache)
                                   {
-                                      auto ent = ENTITY(i);
+                                     
                                       logging::Info("%u", ent->player_info.friendsID);
                                   }
                               });
@@ -112,7 +112,7 @@ bool isIdle()
 
 static void checkAFK()
 {
-    for (int i = 1; i < g_GlobalVars->maxClients; i++)
+    for (int i = 1; i < g_GlobalVars->maxClients; ++i)
     {
         if (soundcache::GetSoundLocation(i))
         {
@@ -132,7 +132,7 @@ static void checkAFK()
 
 static void init()
 {
-    for (size_t i = 0; i < afkTicks.size(); i++)
+    for (size_t i = 0; i < afkTicks.size(); ++i)
     {
         afkTicks[i].update();
     }
@@ -148,7 +148,7 @@ static void addCrumbs(CachedEntity *target, Vector corner = g_pLocalPlayer->v_Or
     {
         Vector dist       = corner - g_pLocalPlayer->v_Origin;
         int maxiterations = floor(corner.DistTo(g_pLocalPlayer->v_Origin)) / 40;
-        for (int i = 0; i < maxiterations; i++)
+        for (int i = 0; i < maxiterations; ++i)
         {
             breadcrumbs.push_back(g_pLocalPlayer->v_Origin + dist / vectorMax(vectorAbs(dist)) * 40.0f * (i + 1));
         }
@@ -156,7 +156,7 @@ static void addCrumbs(CachedEntity *target, Vector corner = g_pLocalPlayer->v_Or
 
     Vector dist       = target->m_vecOrigin() - corner;
     int maxiterations = floor(corner.DistTo(target->m_vecOrigin())) / 40;
-    for (int i = 0; i < maxiterations; i++)
+    for (int i = 0; i < maxiterations; ++i)
     {
         breadcrumbs.push_back(corner + dist / vectorMax(vectorAbs(dist)) * 40.0f * (i + 1));
     }
@@ -170,7 +170,7 @@ static void addCrumbPair(CachedEntity *player1, CachedEntity *player2, std::pair
     {
         Vector dist       = corner1 - player1->m_vecOrigin();
         int maxiterations = floor(corner1.DistTo(player1->m_vecOrigin())) / 40;
-        for (int i = 0; i < maxiterations; i++)
+        for (int i = 0; i < maxiterations; ++i)
         {
             breadcrumbs.push_back(player1->m_vecOrigin() + dist / vectorMax(vectorAbs(dist)) * 40.0f * (i + 1));
         }
@@ -178,7 +178,7 @@ static void addCrumbPair(CachedEntity *player1, CachedEntity *player2, std::pair
     {
         Vector dist       = corner2 - corner1;
         int maxiterations = floor(corner2.DistTo(corner1)) / 40;
-        for (int i = 0; i < maxiterations; i++)
+        for (int i = 0; i < maxiterations; ++i)
         {
             breadcrumbs.push_back(corner1 + dist / vectorMax(vectorAbs(dist)) * 40.0f * (i + 1));
         }
@@ -186,7 +186,7 @@ static void addCrumbPair(CachedEntity *player1, CachedEntity *player2, std::pair
     {
         Vector dist       = player2->m_vecOrigin() - corner2;
         int maxiterations = floor(corner2.DistTo(player2->m_vecOrigin())) / 40;
-        for (int i = 0; i < maxiterations; i++)
+        for (int i = 0; i < maxiterations; ++i)
         {
             breadcrumbs.push_back(corner2 + dist / vectorMax(vectorAbs(dist)) * 40.0f * (i + 1));
         }
@@ -359,9 +359,9 @@ static void cm()
         {
             if (ENTITY(valid_target)->player_info.friendsID != steamid)
             {
-                for (int i = 1; i <= ent_count; i++)
+                for (auto const &entity: entity_cache::player_cache)
                 {
-                    auto entity = ENTITY(i);
+               
                     if (!isValidTarget(entity))
                         continue;
                     // No enemy check, since steamid is very specific
@@ -393,9 +393,9 @@ static void cm()
 
                 if (accountid != ENTITY(valid_target)->player_info.friendsID)
                 {
-                    for (int i = 1; i <= ent_count; i++)
+                    for (auto const &entity: entity_cache::player_cache)
                     {
-                        auto entity = ENTITY(i);
+                      
                         if (!isValidTarget(entity))
                             continue;
                         if (entity->m_bEnemy())
@@ -420,9 +420,9 @@ static void cm()
         {
             if (!playerlist::IsFriend(ENTITY(valid_target)))
             {
-                for (int i = 1; i <= ent_count; i++)
+                for (auto const &entity: entity_cache::player_cache)
                 {
-                    auto entity = ENTITY(i);
+                    
                     if (!isValidTarget(entity))
                         continue;
                     if (entity->m_bEnemy())
@@ -453,10 +453,10 @@ static void cm()
         // Try to get a new target
         if (!followcart)
         {
-            int ent_count = g_IEngine->GetMaxClients();
-            for (int i = 1; i <= ent_count; i++)
+         
+            for (auto const &entity: entity_cache::player_cache)
             {
-                auto entity = ENTITY(i);
+              
                 if (!isValidTarget(entity))
                     continue;
                 if (!follow_target)
@@ -478,22 +478,22 @@ static void cm()
                         continue;
                     // check if new target has a higher priority than current
                     // target
-                    if (ClassPriority(ENTITY(follow_target)) >= ClassPriority(ENTITY(i)))
+                    if (ClassPriority(ENTITY(follow_target)) >= ClassPriority(entity))
                         continue;
                 }
                 if (startFollow(entity, isNavBotCM))
                 {
                     // ooooo, a target
                     navinactivity.update();
-                    follow_target = i;
-                    afkTicks[i].update(); // set afk time to 03
+                    follow_target = entity->m_IDX;
+                    afkTicks[entity->m_IDX].update(); // set afk time to 03
                     break;
                 }
             }
         }
         else
         {
-            for (auto &entity : entity_cache::valid_ents)
+            for (auto const &entity : entity_cache::valid_ents)
             {
                 if (!isValidTarget(entity))
                     continue;
@@ -618,7 +618,7 @@ static void cm()
 
     // Prune old and close crumbs that we wont need anymore, update idle
     // timer too
-    for (size_t i = 0; i < breadcrumbs.size(); i++)
+    for (size_t i = 0; i < breadcrumbs.size(); ++i)
     {
         if (loc_orig.DistTo(breadcrumbs.at(i)) < 60.f)
         {
@@ -728,7 +728,7 @@ static void draw()
         return;
     if (breadcrumbs.size() < 2)
         return;
-    for (size_t i = 0; i < breadcrumbs.size() - 1; i++)
+    for (size_t i = 0; i < breadcrumbs.size() - 1; ++i)
     {
         Vector wts1, wts2;
         if (draw::WorldToScreen(breadcrumbs[i], wts1) && draw::WorldToScreen(breadcrumbs[i + 1], wts2))

--- a/src/hacks/FollowBot.cpp
+++ b/src/hacks/FollowBot.cpp
@@ -354,7 +354,6 @@ static void cm()
     {
         auto &valid_target = follow_target;
         // Find a target with the steam id, as it is prioritized
-        auto ent_count = g_IEngine->GetMaxClients();
         if (steamid)
         {
             if (ENTITY(valid_target)->player_info.friendsID != steamid)

--- a/src/hacks/HeadESP.cpp
+++ b/src/hacks/HeadESP.cpp
@@ -26,11 +26,12 @@ static void cm()
 {
     if (*mode == 0)
         return;
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &pEntity : entity_cache::player_cache)
     {
+        int i = pEntity->m_IDX;
         if (g_pLocalPlayer->entity_idx == i)
             continue;
-        CachedEntity *pEntity = ENTITY(i);
+
         if (CE_BAD(pEntity) || !pEntity->m_bAlivePlayer())
         {
             drawEsp[i] = false;
@@ -57,12 +58,10 @@ void draw()
 {
     if (*mode == 0)
         return;
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &pEntity : entity_cache::player_cache)
     {
+        int i = pEntity->m_IDX;
         if (!drawEsp[i])
-            continue;
-        CachedEntity *pEntity = ENTITY(i);
-        if (CE_BAD(pEntity) || !pEntity->m_bAlivePlayer())
             continue;
         if (pEntity == LOCAL_E)
             continue;
@@ -91,14 +90,14 @@ void draw()
                     steamID = info.friendsID;
                 if (playerlist::AccessData(steamID).state == playerlist::k_EState::CAT)
                     draw::RectangleTextured(out.x - size / 2, out.y - size / 2, size, size, colors::white, idspec, 2 * 64, 1 * 64, 64, 64, 0);
-                for (int i = 0; i < 4; i++)
+                for (int i = 0; i < 4; ++i)
                 {
                     if (steamID == steamidarray[i])
                     {
                         static int ii = 1;
                         while (i > 3)
                         {
-                            ii++;
+                            ++ii;
                             i -= 4;
                         }
                         draw::RectangleTextured(out.x - size / 2, out.y - size / 2, size, size, colors::white, idspec, i * 64, ii * 64, 64, 64, 0);

--- a/src/hacks/KillfeedColor.cpp
+++ b/src/hacks/KillfeedColor.cpp
@@ -47,7 +47,7 @@ void DrawText_hook(int *_this, int x, int y, vgui::HFont hFont, Color clr, const
         if (last_sort_tickcount != tickcount)
         {
             player_names.clear();
-            for (int i = 1; i < g_IEngine->GetMaxClients(); i++)
+            for (int i = 1; i < g_IEngine->GetMaxClients(); ++i)
             {
                 player_info_s player_info;
                 if (GetPlayerInfo(i, &player_info))

--- a/src/hacks/MCHealthbar.cpp
+++ b/src/hacks/MCHealthbar.cpp
@@ -16,9 +16,9 @@ static std::vector<textures::sprite> absorption;
 static std::vector<textures::sprite> hearts;
 
 static InitRoutine init_textures([]() {
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < 2; ++i)
         absorption.push_back(textures::atlas().create_sprite(320 + 64 * i, 64, 64, 64));
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 3; ++i)
         hearts.push_back(textures::atlas().create_sprite(256 + 64 * i, 192, 64, 64));
 });
 
@@ -40,7 +40,7 @@ void draw_func()
     int absorb_halfh          = ((float) absorption_health / (float) maxAdditionalHealth) * 20.0f;
     int absorb_fullh          = (absorb_halfh - 1) / 2;
     float iconPixel           = (iconSize / 8);
-    for (int i = 0; i < 10; i++)
+    for (int i = 0; i < 10; ++i)
     {
         // (iconSize / 8) = 1 pixel in the icon
 
@@ -55,7 +55,7 @@ void draw_func()
                            colors::white); // empty
     }
     if (absorb_halfh >= 1.0f)
-        for (int i = 0; i < 10; i++)
+        for (int i = 0; i < 10; ++i)
         {
 
             if (absorb_fullh >= i + 1)

--- a/src/hacks/Misc.cpp
+++ b/src/hacks/Misc.cpp
@@ -414,7 +414,7 @@ void Draw()
     }*/
     if (show_spectators)
     {
-        for (auto const &ent: entity_cache::player_cache)
+        for (auto const &ent: entity_cache::valid_ents)
         {
             // Assign the for loops tick number to an ent
             

--- a/src/hacks/Misc.cpp
+++ b/src/hacks/Misc.cpp
@@ -18,10 +18,9 @@
 #include "filesystem.h"
 #include "DetourHook.hpp"
 #include "AntiCheatBypass.hpp"
-
+#include <Warp.hpp>
 #include "hack.hpp"
 #include <thread>
-
 namespace hacks::shared::misc
 {
 #if !ENFORCE_STREAM_SAFETY && ENABLE_VISUALS
@@ -40,7 +39,6 @@ static settings::Boolean ping_reducer{ "misc.ping-reducer.enable", "false" };
 static settings::Int force_ping{ "misc.ping-reducer.target", "0" };
 static settings::Boolean force_wait{ "misc.force-enable-wait", "true" };
 static settings::Boolean scc{ "misc.scoreboard.match-custom-team-colors", "false" };
-
 #if ENABLE_VISUALS
 static settings::Boolean debug_info{ "misc.debug-info", "false" };
 static settings::Boolean show_spectators{ "misc.show-spectators", "false" };
@@ -137,7 +135,7 @@ int getCarriedBuilding()
 {
     if (CE_INT(LOCAL_E, netvar.m_bCarryingObject))
         return HandleToIDX(CE_INT(LOCAL_E, netvar.m_hCarriedObject));
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         if (ent->m_Type() != ENTITY_BUILDING)
             continue;
@@ -162,7 +160,7 @@ struct wireframe_data
 std::vector<wireframe_data> wireframe_queue;
 void QueueWireframeHitboxes(hitbox_cache::EntityHitboxCache &hb_cache)
 {
-    for (int i = 0; i < hb_cache.GetNumHitboxes(); i++)
+    for (int i = 0; i < hb_cache.GetNumHitboxes(); ++i)
     {
         auto hb        = hb_cache.GetHitbox(i);
         Vector raw_min = hb->bbox->bbmin;
@@ -209,9 +207,9 @@ void CreateMove()
 #if ENABLE_VISUALS
     if (misc_drawhitboxes)
     {
-        for (int i = 0; i <= g_IEngine->GetMaxClients(); i++)
+        for (auto const &ent : entity_cache::player_cache)
         {
-            auto ent = ENTITY(i);
+
             if (CE_INVALID(ent) || ent == LOCAL_E || (!misc_drawhitboxes_dead && !ent->m_bAlivePlayer()))
                 continue;
             QueueWireframeHitboxes(ent->hitboxes);
@@ -406,7 +404,7 @@ void Draw()
 {
     if (misc_drawhitboxes)
     {
-        for (auto &entry : wireframe_queue)
+        for (auto const &entry : wireframe_queue)
             DrawWireframeHitbox(entry);
         wireframe_queue.clear();
     }
@@ -416,12 +414,12 @@ void Draw()
     }*/
     if (show_spectators)
     {
-        for (int i = 0; i < PLAYER_ARRAY_SIZE; i++)
+        for (auto const &ent: entity_cache::player_cache)
         {
             // Assign the for loops tick number to an ent
-            CachedEntity *ent = ENTITY(i);
+            
             player_info_s info;
-            if (!CE_BAD(ent) && ent != LOCAL_E && ent->m_Type() == ENTITY_PLAYER && HandleToIDX(CE_INT(ent, netvar.hObserverTarget)) == LOCAL_E->m_IDX && CE_INT(ent, netvar.iObserverMode) >= 4 && GetPlayerInfo(i, &info))
+            if (ent != LOCAL_E && ent->m_Type() == ENTITY_PLAYER && HandleToIDX(CE_INT(ent, netvar.hObserverTarget)) == LOCAL_E->m_IDX && CE_INT(ent, netvar.iObserverMode) >= 4 && GetPlayerInfo(ent->m_IDX, &info))
             {
                 auto observermode = "N/A";
                 rgba_t color      = colors::green;
@@ -514,7 +512,7 @@ void Draw()
         //if (TF2C) AddSideString(colors::white, "Crits: %i", s_bCrits);
         //if (TF2C) AddSideString(colors::white, "CritMult: %i",
         RemapValClampedNC( CE_INT(LOCAL_E, netvar.iCritMult), 0, 255, 1.0, 6 ));
-        for (int i = 0; i <= HIGHEST_ENTITY; i++) {
+        for (int i = 0; i <= HIGHEST_ENTITY; ++i) {
             CachedEntity* e = ENTITY(i);
             if (CE_GOOD(e)) {
                 if (e->m_Type() == EntityType::ENTITY_PROJECTILE) {
@@ -689,7 +687,7 @@ void DumpRecvTable(CachedEntity *ent, RecvTable *table, int depth, const char *f
     bool forcetable = ft && strlen(ft);
     if (!forcetable || !strcmp(ft, table->GetName()))
         logging::Info("==== TABLE: %s", table->GetName());
-    for (int i = 0; i < table->GetNumProps(); i++)
+    for (int i = 0; i < table->GetNumProps(); ++i)
     {
         RecvProp *prop = table->GetProp(i);
         if (!prop)
@@ -749,7 +747,7 @@ static CatCommand dump_vars_by_name("debug_dump_netvars_name", "Dump netvars of 
                                         if (args.ArgC() < 2)
                                             return;
                                         std::string name(args.Arg(1));
-                                        for (auto &ent : entity_cache::valid_ents)
+                                        for (auto const &ent : entity_cache::valid_ents)
                                         {
 
                                             ClientClass *clz = RAW_ENT(ent)->GetClientClass();
@@ -772,7 +770,7 @@ static CatCommand debug_print_weaponid("debug_weaponid", "Print the weapon IDs o
                                                return;
                                            int *hWeapons = &CE_INT(LOCAL_E, netvar.hMyWeapons);
                                            // Go through the handle array and search for the item
-                                           for (int i = 0; hWeapons[i]; i++)
+                                           for (int i = 0; hWeapons[i]; ++i)
                                            {
                                                if (IDX_BAD(HandleToIDX(hWeapons[i])))
                                                    continue;
@@ -827,7 +825,7 @@ Color &GetPlayerColor(int idx, int team, bool dead = false)
     }
 
     if (dead)
-        for (int i = 0; i < 3; i++)
+        for (int i = 0; i < 3; ++i)
             returnColor[i] /= 1.5f;
 
     return returnColor;
@@ -868,18 +866,18 @@ static InitRoutine init(
 
         // Construct BytePatch1
         std::vector<unsigned char> patch1 = { 0xE8 };
-        for (size_t i = 0; i < sizeof(uintptr_t); i++)
+        for (size_t i = 0; i < sizeof(uintptr_t); ++i)
             patch1.push_back(((unsigned char *) &relAddr1)[i]);
-        for (int i = patch1.size(); i < 6; i++)
+        for (int i = patch1.size(); i < 6; ++i)
             patch1.push_back(0x90);
 
         // Construct BytePatch2
         std::vector<unsigned char> patch2 = { 0xE8 };
-        for (size_t i = 0; i < sizeof(uintptr_t); i++)
+        for (size_t i = 0; i < sizeof(uintptr_t); ++i)
             patch2.push_back(((unsigned char *) &relAddr2)[i]);
         patch2.push_back(0x8B);
         patch2.push_back(0x00);
-        for (int i = patch2.size(); i < 27; i++)
+        for (int i = patch2.size(); i < 27; ++i)
             patch2.push_back(0x90);
 
         patch_scoreboardcolor1 = std::make_unique<BytePatch>(addr1, patch1);
@@ -1129,7 +1127,7 @@ static InitRoutine init(
 /*void DumpRecvTable(CachedEntity* ent, RecvTable* table, int depth, const char*
 ft, unsigned acc_offset) { bool forcetable = ft && strlen(ft); if (!forcetable
 || !strcmp(ft, table->GetName())) logging::Info("==== TABLE: %s",
-table->GetName()); for (int i = 0; i < table->GetNumProps(); i++) { RecvProp*
+table->GetName()); for (int i = 0; i < table->GetNumProps(); ++i) { RecvProp*
 prop = table->GetProp(i); if (!prop) continue; if (prop->GetDataTable()) {
             DumpRecvTable(ent, prop->GetDataTable(), depth + 1, ft, acc_offset +
 prop->GetOffset());

--- a/src/hacks/MiscAimbot.cpp
+++ b/src/hacks/MiscAimbot.cpp
@@ -38,7 +38,7 @@ std::pair<CachedEntity *, Vector> FindBestEnt(bool teammate, bool Predict, bool 
 
     bool shouldBacktrack = backtrack::backtrackEnabled() && !backtrack::hasData();
 
-    for (int i = 0; i < 1; i++)
+    for (int i = 0; i < 1; ++i)
     {
         if (prevent != -1)
         {
@@ -123,9 +123,8 @@ std::pair<CachedEntity *, Vector> FindBestEnt(bool teammate, bool Predict, bool 
         }
     }
     prevent = -1;
-    for (int i = 0; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        CachedEntity *ent = ENTITY(i);
         if (CE_BAD(ent) || !(ent->m_bAlivePlayer()) || (teammate && ent->m_iTeam() != LOCAL_E->m_iTeam()) || ent == LOCAL_E)
             continue;
         if (!teammate && ent->m_iTeam() == LOCAL_E->m_iTeam())
@@ -315,9 +314,9 @@ static void SapperAimbot()
     CachedEntity *target = nullptr;
     float distance       = FLT_MAX;
 
-    for (int i = 0; i < entity_cache::max; i++)
+    for (int i = 32; i < entity_cache::max; ++i)
     {
-        CachedEntity *ent = ENTITY(i);
+        CachedEntity* ent = ENTITY(i);
         if (CE_BAD(ent))
             continue;
         if (ent->m_Type() != ENTITY_BUILDING)
@@ -455,13 +454,9 @@ CachedEntity *targetBuilding(bool priority)
     float wrench_range   = re::C_TFWeaponBaseMelee::GetSwingRange(RAW_ENT(LOCAL_W));
     CachedEntity *target = nullptr;
     float distance       = FLT_MAX;
-    for (int i = 0; i < entity_cache::max; i++)
+    for (auto const &ent: entity_cache::valid_ents)
     {
-        CachedEntity *ent = ENTITY(i);
-
-        if (CE_BAD(ent))
-            continue;
-
+        
         // can't exactly repair Merasmus
         if (ent->m_Type() != ENTITY_BUILDING)
             continue;

--- a/src/hacks/MiscAimbot.cpp
+++ b/src/hacks/MiscAimbot.cpp
@@ -201,8 +201,6 @@ std::pair<CachedEntity *, Vector> FindBestEnt(bool teammate, bool Predict, bool 
         backtrack::MoveToTick(*best_data);
     return { bestent, predicted };
 }
-static float slow_change_dist_y{};
-static float slow_change_dist_p{};
 void DoSlowAim(Vector &input_angle, int speed)
 {
     auto viewangles = current_user_cmd->viewangles;

--- a/src/hacks/MiscPlayerInfo.cpp
+++ b/src/hacks/MiscPlayerInfo.cpp
@@ -52,9 +52,9 @@ void Paint()
 {
     if (!*draw_kda && !*mafia_city)
         return;
-    for (int i = 0; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        CachedEntity *ent = ENTITY(i);
+        int i = ent->m_IDX;
         if (CE_BAD(ent))
             continue;
         if (ent->m_Type() != ENTITY_PLAYER || !ent->player_info.friendsID)

--- a/src/hacks/NavBot.cpp
+++ b/src/hacks/NavBot.cpp
@@ -97,7 +97,7 @@ bool shouldSearchAmmo()
         return false;
     if (g_pLocalPlayer->holding_sniper_rifle && CE_INT(LOCAL_E, netvar.m_iAmmo + 4) <= 5)
         return true;
-    for (int i = 0; weapon_list[i]; i++)
+    for (int i = 0; weapon_list[i]; ++i)
     {
         int handle = weapon_list[i];
         int eid    = HandleToIDX(handle);
@@ -115,7 +115,7 @@ bool shouldSearchAmmo()
 std::vector<CachedEntity *> getDispensers()
 {
     std::vector<CachedEntity *> entities;
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         if (ent->m_iClassID() != CL_CLASS(CObjectDispenser) || ent->m_iTeam() != g_pLocalPlayer->team)
             continue;
@@ -137,7 +137,7 @@ std::vector<CachedEntity *> getDispensers()
 std::vector<CachedEntity *> getEntities(const std::vector<k_EItemType> &itemtypes)
 {
     std::vector<CachedEntity *> entities;
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         for (auto &itemtype : itemtypes)
         {
@@ -259,9 +259,9 @@ static std::pair<CachedEntity *, float> getNearestPlayerDistance()
 {
     float distance         = FLT_MAX;
     CachedEntity *best_ent = nullptr;
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        CachedEntity *ent = ENTITY(i);
+        
         if (CE_VALID(ent) && ent->m_vecDormantOrigin() && g_pPlayerResource->isAlive(ent->m_IDX) && ent->m_bEnemy() && g_pLocalPlayer->v_Origin.DistTo(ent->m_vecOrigin()) < distance && player_tools::shouldTarget(ent) && !IsPlayerInvisible(ent))
         {
             distance = g_pLocalPlayer->v_Origin.DistTo(*ent->m_vecDormantOrigin());
@@ -377,7 +377,7 @@ void refreshLocalBuildings()
         myDispenser = nullptr;
         if (CE_GOOD(LOCAL_E))
         {
-            for (auto &ent : entity_cache::valid_ents)
+            for (auto const &ent : entity_cache::valid_ents)
             {
                 if (ent->m_bEnemy() || !ent->m_bAlivePlayer())
                     continue;
@@ -491,14 +491,14 @@ void updateEnemyBlacklist(int slot)
     std::unordered_map<CachedEntity *, std::vector<CNavArea *>> ent_marked_normal_slight_danger;
 
     std::vector<std::pair<CachedEntity *, Vector>> checked_origins;
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        CachedEntity *ent = ENTITY(i);
+        
         // Entity is generally invalid, ignore
-        if (CE_INVALID(ent) || !g_pPlayerResource->isAlive(i))
+        if (CE_INVALID(ent) || !g_pPlayerResource->isAlive(ent->m_IDX))
             continue;
         // On our team, do not care
-        if (g_pPlayerResource->GetTeam(i) == g_pLocalPlayer->team)
+        if (g_pPlayerResource->GetTeam(ent->m_IDX) == g_pLocalPlayer->team)
             continue;
 
         bool is_dormant = CE_BAD(ent);
@@ -744,7 +744,7 @@ bool runReload()
     // Get closest enemy to vicheck
     CachedEntity *closest_visible_enemy = nullptr;
     float best_distance                 = FLT_MAX;
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         if (!ent->m_bAlivePlayer() || !ent->m_bEnemy())
             continue;
@@ -841,13 +841,14 @@ bool stayNear()
 
     int calls = 0;
     // Test all entities
-    for (int i = lowest_check_index; i <= g_IEngine->GetMaxClients(); i++)
+    for (int i = lowest_check_index; i <= g_IEngine->GetMaxClients(); ++i)
     {
+        CachedEntity* ent = ENTITY(i);
         if (calls >= advance_count)
             break;
         calls++;
         lowest_check_index++;
-        CachedEntity *ent = ENTITY(i);
+        
         if (!isStayNearTargetValid(ent))
         {
             calls--;
@@ -1037,7 +1038,7 @@ bool snipeSentries()
     if (!snipe_sentries_shortrange && (g_pLocalPlayer->clazz == tf_scout || g_pLocalPlayer->clazz == tf_pyro))
         return false;
 
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         // Invalid sentry
         if (!isSnipeTargetValid(ent))

--- a/src/hacks/Radar.cpp
+++ b/src/hacks/Radar.cpp
@@ -239,7 +239,7 @@ void Draw()
     if (enemies_over_teammates)
         enemies.clear();
     std::vector<CachedEntity *> sentries;
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         if (CE_INVALID(ent))
             continue;
@@ -297,9 +297,9 @@ static InitRoutine init(
             for (int j = 0; j < 9; ++j)
                 tx_class[i].push_back(textures::atlas().create_sprite(j * 64, 320 + i * 64, 64, 64));
         }
-        for (int i = 0; i < 2; i++)
+        for (int i = 0; i < 2; ++i)
             tx_buildings.push_back(textures::atlas().create_sprite(576 + i * 64, 320, 64, 64));
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; i < 4; ++i)
             tx_sentry.push_back(textures::atlas().create_sprite(640 + i * 64, 256, 64, 64));
         logging::Info("Radar sprites loaded");
         EC::Register(EC::Draw, Draw, "radar", EC::average);

--- a/src/hacks/SkinChanger.cpp
+++ b/src/hacks/SkinChanger.cpp
@@ -46,7 +46,7 @@ CAttribute::CAttribute(uint16_t iAttributeDefinitionIndex, float flValue)
 
 float CAttributeList::GetAttribute(int defindex)
 {
-    for (int i = 0; i < m_Attributes.Count(); i++)
+    for (int i = 0; i < m_Attributes.Count(); ++i)
     {
         const auto &a = m_Attributes[i];
         if (a.defidx == defindex)
@@ -59,7 +59,7 @@ float CAttributeList::GetAttribute(int defindex)
 
 void CAttributeList::RemoveAttribute(int index)
 {
-    for (int i = 0; i < m_Attributes.Count(); i++)
+    for (int i = 0; i < m_Attributes.Count(); ++i)
     {
         const auto &a = m_Attributes[i];
         if (a.defidx == index)
@@ -81,7 +81,7 @@ void CAttributeList::SetAttribute(int index, float value)
     SetRuntimeAttributeValueFn(this, attrib, value);
     // The code below actually is unused now - but I'll keep it just in case!
     // Let's check if attribute exists already. We don't want dupes.
-    /*for (int i = 0; i < m_Attributes.Count(); i++) {
+    /*for (int i = 0; i < m_Attributes.Count(); ++i) {
         auto& a = m_Attributes[i];
         if (a.defidx == index) {
             a.value = value;
@@ -184,7 +184,7 @@ static CatCommand dump_attrs("skinchanger_debug_attrs", "Dump attributes",
                              {
                                  CAttributeList *list = (CAttributeList *) ((uintptr_t) (RAW_ENT(LOCAL_W)) + netvar.AttributeList);
                                  logging::Info("ATTRIBUTE LIST: %i", list->m_Attributes.Size());
-                                 for (int i = 0; i < list->m_Attributes.Size(); i++)
+                                 for (int i = 0; i < list->m_Attributes.Size(); ++i)
                                  {
                                      logging::Info("%i %.2f", list->m_Attributes[i].defidx, list->m_Attributes[i].value);
                                  }
@@ -290,7 +290,7 @@ void FrameStageNotify(int stage)
         return;
     if (!re::C_BaseCombatWeapon::IsBaseCombatWeapon(my_weapon_ptr))
         return;
-    for (int i = 0; i < 4; i++)
+    for (int i = 0; i < 4; ++i)
     {
         handle = weapon_list[i];
         eid    = HandleToIDX(handle);
@@ -326,7 +326,7 @@ void DrawText()
     {
         AddSideString(format("dIDX: ", CE_INT(LOCAL_W, netvar.iItemDefinitionIndex)));
         list = (CAttributeList *) ((uintptr_t) (RAW_ENT(LOCAL_W)) + netvar.AttributeList);
-        for (int i = 0; i < list->m_Attributes.Size(); i++)
+        for (int i = 0; i < list->m_Attributes.Size(); ++i)
         {
             AddSideString(format('[', i, "] ", list->m_Attributes[i].defidx, ": ", list->m_Attributes[i].value));
         }
@@ -402,7 +402,7 @@ void Load(std::string filename, bool merge)
         logging::Info("Reading %i entries...", size);
         if (!merge)
             modifier_map.clear();
-        for (int i = 0; i < size; i++)
+        for (int i = 0; i < size; ++i)
         {
             int defindex;
             BINARY_FILE_READ(file, defindex);

--- a/src/hacks/Spam.cpp
+++ b/src/hacks/Spam.cpp
@@ -182,8 +182,9 @@ int QueryPlayer(Query query)
     }
     std::vector<int> candidates{};
     int index_result = 0;
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
+        int i = ent->m_IDX;
         if (PlayerPassesQuery(query, i))
         {
             candidates.push_back(i);

--- a/src/hacks/SpellForcer.cpp
+++ b/src/hacks/SpellForcer.cpp
@@ -247,7 +247,7 @@ void Draw()
     int players_above = 0;
 
     // Check if there is a valid player exceeding our IDX
-    for (int i = g_pLocalPlayer->entity_idx + 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (int i = g_pLocalPlayer->entity_idx + 1; i <= g_IEngine->GetMaxClients(); ++i)
     {
         if (g_pPlayerResource->isValid(i))
         {

--- a/src/hacks/SpyAlert.cpp
+++ b/src/hacks/SpyAlert.cpp
@@ -41,9 +41,9 @@ void Draw()
         last_say = 0;
     for (auto const &ent: entity_cache::player_cache)
     {
-        if (CE_INT(ent, netvar.iClass) != tf_class::tf_spy)
+        if (ent->m_iClassID() != tf_spy)
             continue;
-        if (CE_INT(ent, netvar.iTeamNum) == g_pLocalPlayer->team)
+        if (!ent->m_bEnemy())
             continue;
         if (IsPlayerInvisible(ent) && !invisible)
             continue;

--- a/src/hacks/SpyAlert.cpp
+++ b/src/hacks/SpyAlert.cpp
@@ -29,7 +29,7 @@ void Draw()
     PROF_SECTION(DRAW_SpyAlert)
     if (!enable)
         return;
-    CachedEntity *closest_spy, *ent;
+    CachedEntity *closest_spy;
     float closest_spy_distance, distance;
     int spy_count;
     if (g_pLocalPlayer->life_state)
@@ -39,13 +39,8 @@ void Draw()
     spy_count            = 0;
     if (last_say > g_GlobalVars->curtime)
         last_say = 0;
-    for (int i = 0; i <= HIGHEST_ENTITY && i <= MAX_PLAYERS; i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        ent = ENTITY(i);
-        if (CE_BAD(ent))
-            continue;
-        if (CE_BYTE(ent, netvar.iLifeState))
-            continue;
         if (CE_INT(ent, netvar.iClass) != tf_class::tf_spy)
             continue;
         if (CE_INT(ent, netvar.iTeamNum) == g_pLocalPlayer->team)

--- a/src/hacks/Tracers.cpp
+++ b/src/hacks/Tracers.cpp
@@ -126,7 +126,7 @@ void draw()
     // Loop all players
     if (*buildings)
     {
-        for (auto &ent : entity_cache::valid_ents)
+        for (auto const &ent : entity_cache::valid_ents)
         {
             // Get and check player
             const uint16_t curr_idx = ent->m_IDX;
@@ -182,11 +182,12 @@ void draw()
     }
     else
     {
-        for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+        for (auto const &ent: entity_cache::player_cache)
         {
             // Get and check player
-            auto ent = ENTITY(i);
+   
             Vector origin;
+            int i = ent->m_IDX;
             std::optional<rgba_t> color = std::nullopt;
 
             if (CE_INVALID(ent))

--- a/src/hacks/Trigger.cpp
+++ b/src/hacks/Trigger.cpp
@@ -62,7 +62,7 @@ void CreateMove()
     if (shouldBacktrack)
     {
         float target_range = EffectiveTargetingRange();
-        for (auto &ent_data : tf2::backtrack::bt_data)
+        for (auto const &ent_data : tf2::backtrack::bt_data)
         {
             if (state_good)
                 break;

--- a/src/hacks/Walkbot.cpp
+++ b/src/hacks/Walkbot.cpp
@@ -126,7 +126,7 @@ struct walkbot_node_s
 
     connection free_connection() const
     {
-        for (connection i = 0; i < MAX_CONNECTIONS; i++)
+        for (connection i = 0; i < MAX_CONNECTIONS; ++i)
         {
             if (connections[i].free())
                 return i;
@@ -147,7 +147,7 @@ struct walkbot_node_s
 
     void unlink(index_t node)
     {
-        for (connection i = 0; i < MAX_CONNECTIONS; i++)
+        for (connection i = 0; i < MAX_CONNECTIONS; ++i)
         {
             if (connections[i].good() and connections[i].node == node)
             {
@@ -222,7 +222,7 @@ std::chrono::system_clock::time_point time{};
 // no free slots exist
 index_t free_node()
 {
-    for (index_t i = 0; i < nodes.size(); i++)
+    for (index_t i = 0; i < nodes.size(); ++i)
     {
         if (not(nodes[i].flags & NF_GOOD))
             return i;
@@ -239,7 +239,7 @@ using state::nodes;
 bool HasLowAmmo()
 {
     int *weapon_list = (int *) ((unsigned) (RAW_ENT(LOCAL_E)) + netvar.hMyWeapons);
-    for (int i = 0; weapon_list[i]; i++)
+    for (int i = 0; weapon_list[i]; ++i)
     {
         int handle = weapon_list[i];
         int eid    = HandleToIDX(handle);
@@ -266,7 +266,7 @@ void DeleteNode(index_t node)
         return;
     logging::Info("[wb] Deleting node %u", node);
     auto &n = nodes[node];
-    for (size_t i = 0; i < MAX_CONNECTIONS; i++)
+    for (size_t i = 0; i < MAX_CONNECTIONS; ++i)
     {
         if (n.connections[i].good() and node_good(n.connections[i].node))
         {
@@ -639,7 +639,7 @@ CatCommand c_toggle_cf_ammo("wb_conn_ammo", "Toggle 'ammo' flag on connection fr
                                 auto b = state::closest();
                                 if (not(a and b))
                                     return;
-                                for (connection i = 0; i < MAX_CONNECTIONS; i++)
+                                for (connection i = 0; i < MAX_CONNECTIONS; ++i)
                                 {
                                     auto &c = a->connections[i];
                                     if (c.free())
@@ -660,7 +660,7 @@ CatCommand c_toggle_cf_health("wb_conn_health", "Toggle 'health' flag on connect
                                   auto b = state::closest();
                                   if (not(a and b))
                                       return;
-                                  for (connection i = 0; i < MAX_CONNECTIONS; i++)
+                                  for (connection i = 0; i < MAX_CONNECTIONS; ++i)
                                   {
                                       auto &c = a->connections[i];
                                       if (c.free())
@@ -681,7 +681,7 @@ CatCommand c_toggle_cf_sticky("wb_conn_sticky", "Toggle 'Sticky' flag on connect
                                   auto b = state::closest();
                                   if (not(a and b))
                                       return;
-                                  for (connection i = 0; i < MAX_CONNECTIONS; i++)
+                                  for (connection i = 0; i < MAX_CONNECTIONS; ++i)
                                   {
                                       auto &c = a->connections[i];
                                       if (c.free())
@@ -709,7 +709,7 @@ CatCommand c_info("wb_dump", "Show info",
                       logging::Info("[wb] Flags: Duck=%d, Jump=%d, Raw=%u", n.flags & NF_DUCK, n.flags & NF_JUMP, n.flags);
                       logging::Info("[wb] X: %.2f | Y: %.2f | Z: %.2f", n.x, n.y, n.z);
                       logging::Info("[wb] Connections:");
-                      for (size_t i = 0; i < MAX_CONNECTIONS; i++)
+                      for (size_t i = 0; i < MAX_CONNECTIONS; ++i)
                       {
                           if (n.connections[i].free())
                               continue;
@@ -739,7 +739,7 @@ CatCommand c_delete_region("wb_delete_region", "Delete region of nodes",
                                        return;
                                    }
                                    bool found_next = false;
-                                   for (size_t i = 0; i < 2; i++) {
+                                   for (size_t i = 0; i < 2; ++i) {
                                        if (n.connections[i] != current) {
                                            next = n.connections[i];
                                            found_next = true;
@@ -765,7 +765,7 @@ void UpdateClosestNode()
     float n_fov   = 360.0f;
     index_t n_idx = BAD_NODE;
 
-    for (index_t i = 0; i < state::nodes.size(); i++)
+    for (index_t i = 0; i < state::nodes.size(); ++i)
     {
         auto &node = state::nodes[i];
 
@@ -795,7 +795,7 @@ index_t FindNearestNode(bool traceray)
     index_t r_node{ BAD_NODE };
     float r_dist{ 65536.0f };
 
-    for (index_t i = 0; i < state::nodes.size(); i++)
+    for (index_t i = 0; i < state::nodes.size(); ++i)
     {
         if (state::node_good(i))
         {
@@ -822,7 +822,7 @@ index_t SelectNextNode()
     }
     auto &n = state::nodes[state::active_node];
     std::vector<index_t> chance{};
-    for (index_t i = 0; i < MAX_CONNECTIONS; i++)
+    for (index_t i = 0; i < MAX_CONNECTIONS; ++i)
     {
         if (n.connections[i].good() and n.connections[i].node != state::last_node and node_good(n.connections[i].node))
         {
@@ -1064,7 +1064,7 @@ void DrawNode(index_t node, bool draw_back)
 
     auto &n = state::nodes[node];
 
-    for (size_t i = 0; i < MAX_CONNECTIONS; i++)
+    for (size_t i = 0; i < MAX_CONNECTIONS; ++i)
     {
         DrawConnection(node, n.connections[i]);
     }
@@ -1111,7 +1111,7 @@ void DrawNode(index_t node, bool draw_back)
 
 void DrawPath()
 {
-    for (index_t i = 0; i < state::nodes.size(); i++)
+    for (index_t i = 0; i < state::nodes.size(); ++i)
     {
         DrawNode(i, true);
     }

--- a/src/hacks/Warp.cpp
+++ b/src/hacks/Warp.cpp
@@ -16,7 +16,7 @@
 #include "MiscTemporary.hpp"
 #include "Think.hpp"
 #include "Aimbot.hpp"
-
+#include <Misc.hpp>
 namespace hacks::tf2::warp
 {
 static settings::Boolean enabled{ "warp.enabled", "false" };
@@ -37,6 +37,7 @@ static settings::Boolean charge_passively{ "warp.charge-passively", "true" };
 static settings::Boolean charge_in_jump{ "warp.charge-passively.jump", "true" };
 static settings::Boolean charge_no_input{ "warp.charge-passively.no-inputs", "false" };
 static settings::Int warp_movement_ratio{ "warp.movement-ratio", "6" };
+settings::Boolean dodge_projectile{ "warp.dodge_proj", "true" };
 static settings::Boolean warp_demoknight{ "warp.demoknight", "false" };
 static settings::Boolean warp_peek{ "warp.peek", "false" };
 static settings::Boolean warp_on_damage{ "warp.on-hit", "false" };
@@ -102,15 +103,15 @@ void DrawWarpStrings()
 }
 #endif
 
-static bool should_charge       = false;
-static int warp_amount          = 0;
-static int warp_amount_override = 0;
-static bool should_melee        = false;
-static bool charged             = false;
-
-static bool should_warp = true;
-static bool was_hurt    = false;
-
+static bool should_charge = false;
+static int warp_amount    = 0;
+int warp_amount_override  = 0;
+static bool should_melee  = false;
+static bool charged       = false;
+static bool was_hurt      = false;
+static bool should_warp   = true;
+static bool warp_dodge    = false;
+static float yaw_amount   = 90.0f;
 // Rapidfire key mode
 static bool key_valid = false;
 
@@ -260,21 +261,81 @@ bool shouldRapidfire()
 
     return buttons_pressed;
 }
+void dodgeProj()
+{
+    if (!LOCAL_E->m_bAlivePlayer() || entity_cache::proj_map.empty() || !dodge_projectile)
+        return;
+    Vector player_pos = RAW_ENT(LOCAL_E)->GetAbsOrigin();
+    for (auto const &[key, val] : entity_cache::proj_map)
+    {
+        if (CE_GOOD(val))
+        {
+            // Since we are sending this warp next tick we need to compensate for fast moving projectiles
+            // 2 Ticks in advance is a fairly safe interval
+            Vector velocity_comp = key * 2 * TICK_INTERVAL;
+            velocity_comp.z -= 2 * TICK_INTERVAL * g_ICvar->FindVar("sv_gravity")->GetFloat() * ProjGravMult(val->m_iClassID(), key.Length());
 
+            Vector proj_next_tik = RAW_ENT(val)->GetAbsOrigin() + velocity_comp;
+            float diff           = proj_next_tik.DistToSqr(player_pos);
+            // Warp sooner for fast moving projectiles.
+            if (diff < (15000 * (key.Length() / 1000)))
+            {
+                trace_t trace;
+                Ray_t ray;
+                ray.Init(proj_next_tik, player_pos, Vector(0, -8, -8), Vector(0, 8, 8));
+                g_ITrace->TraceRay(ray, MASK_SHOT_HULL, &trace::filter_default, &trace);
+                if (trace.DidHit())
+                {
+
+                                       // We need to determine wether the projectile is coming in from the left or right of us so we don't warp into the projectile.
+                    Vector result = GetAimAtAngles(g_pLocalPlayer->v_Eye, RAW_ENT(val)->GetAbsOrigin(), LOCAL_E) - g_pLocalPlayer->v_OrigViewangles;
+
+                    if (0 <= result.y)
+                        yaw_amount = -90.0f;
+                    else
+                        yaw_amount = 90.0f;
+                    if ((IClientEntity *) trace.m_pEnt == RAW_ENT(LOCAL_E))
+                    {
+                        was_hurt   = true;
+                        warp_dodge = true;
+                        entity_cache::proj_map.erase(key);
+                    }
+                } // It didn't hit anything but it has been proven to be very close to us. Dodge. (This is for the huntsman+pills)
+                else
+                {
+                    was_hurt      = true;
+                    warp_dodge    = true;
+                    Vector result = GetAimAtAngles(g_pLocalPlayer->v_Eye, RAW_ENT(val)->GetAbsOrigin(), LOCAL_E) - g_pLocalPlayer->v_OrigViewangles;
+                    if (0 <= result.y)
+                        yaw_amount = -90.0f;
+                    else
+                        yaw_amount = 90.0f;
+                    entity_cache::proj_map.erase(key);
+                }
+            }
+        }
+        else
+        {
+            entity_cache::proj_map.erase(key);
+        }
+    }
+}
 // Should we warp?
 bool shouldWarp(bool check_amount)
 {
+
     return
         // Ingame?
         g_IEngine->IsInGame() &&
-        // Warp key held?
-        (((warp_key && warp_key.isKeyDown())
-          // Hurt warp?
-          || was_hurt
-          // Rapidfire and trying to attack?
-          || shouldRapidfire()) &&
-         // Do we have enough to warp?
-         (!check_amount || warp_amount));
+            // Warp key held?
+            (((warp_key && warp_key.isKeyDown())
+              // Hurt warp?
+              || was_hurt
+              // Rapidfire and trying to attack?
+              || shouldRapidfire()) &&
+             // Do we have enough to warp?
+             (!check_amount || warp_amount)) ||
+        warp_dodge;
 }
 
 // How many ticks of excess we have (for decimal speeds)
@@ -298,6 +359,8 @@ int GetWarpAmount(bool finalTick)
     if (!*maxusrcmdprocessticks)
         max_extra_ticks = INT_MAX;
     float warp_amount_preprocessed = std::max(*speed, 0.05f);
+    if (warp_dodge)
+        warp_amount_preprocessed = 23.0f;
 
     // How many ticks to warp, add excess too
     int warp_amount_processed = std::floor(warp_amount_preprocessed) + std::floor(excess_ticks);
@@ -346,7 +409,7 @@ void Warp(float accumulated_extra_samples, bool finalTick)
 
         // Starts at 1 for the previous packet we already stored
         int packets_sent = 1;
-        for (int i = 0; i < calls; i++)
+        for (int i = 0; i < calls; ++i)
         {
             if (!i)
                 first_warp_tick = true;
@@ -385,6 +448,7 @@ void Warp(float accumulated_extra_samples, bool finalTick)
     if (warp_ticks <= 0)
     {
         was_hurt   = false;
+        warp_dodge = false;
         warp_ticks = 0;
         if (warp_amount_override)
             warp_amount_override = 0;
@@ -423,7 +487,7 @@ int approximateTicksForDist(float distance, float initial_speed, int max_ticks)
             has_booties = true;
     }
     float travelled_dist = 0.0f;
-    for (int i = 0; i <= max_ticks; i++)
+    for (int i = 0; i <= max_ticks; ++i)
     {
         // Compensate for the skullcutter (booties don't speed up, besides with skullcutter)
         travelled_dist += approximateSpeedAtTick(i, initial_speed, is_skullcutter ? (has_booties ? 701.0f : 637.0f) : 750.0f);
@@ -526,6 +590,7 @@ void handleMinigun()
 // This is called first, it subsequently calls all the CreateMove functions.
 void CL_Move_hook(float accumulated_extra_samples, bool bFinalTick)
 {
+
     CL_Move_t original = (CL_Move_t) cl_move_detour.GetOriginalFunc();
     original(accumulated_extra_samples, bFinalTick);
     cl_move_detour.RestorePatch();
@@ -700,7 +765,10 @@ void warpLogic()
             if (yaw_selections.empty())
                 return;
             // Select randomly
-            yaw = yaw_selections[UniformRandomInt(0, yaw_selections.size() - 1)];
+            if (warp_dodge)
+                yaw = yaw_amount;
+            else
+                yaw = yaw_selections[UniformRandomInt(0, yaw_selections.size() - 1)];
         }
         // The yaw we want to achieve
         float actual_yaw = DEG2RAD(yaw);
@@ -730,9 +798,9 @@ void warpLogic()
                 // Find an entity meeting the Criteria and closest to crosshair
                 std::pair<CachedEntity *, float> result{ nullptr, FLT_MAX };
 
-                for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+                for (auto const &ent: entity_cache::player_cache)
                 {
-                    CachedEntity *ent = ENTITY(i);
+                    
                     if (CE_BAD(ent) || !ent->m_bAlivePlayer() || !ent->m_bEnemy() || !player_tools::shouldTarget(ent))
                         continue;
                     // No hitboxes
@@ -1096,6 +1164,7 @@ static InitRoutine init(
         EC::Register(EC::CreateMove, CreateMove, "warp_createmove", EC::very_late);
         EC::Register(EC::CreateMoveWarp, CreateMove, "warp_createmovew", EC::very_late);
         EC::Register(EC::CreateMove_NoEnginePred, CreateMovePrePredict, "warp_prepredict");
+        EC::Register(EC::CreateMove, dodgeProj, "warp_dodgeproj", EC::very_early);
         EC::Register(EC::CreateMoveEarly, CreateMoveEarly, "warp_createmove_early", EC::very_early);
         g_IEventManager2->AddListener(&listener, "player_hurt", false);
         EC::Register(

--- a/src/hacks/Warp.cpp
+++ b/src/hacks/Warp.cpp
@@ -265,9 +265,13 @@ void dodgeProj()
 {
     if (!LOCAL_E->m_bAlivePlayer() || entity_cache::proj_map.empty() || !dodge_projectile)
         return;
-    Vector player_pos = RAW_ENT(LOCAL_E)->GetAbsOrigin();
-    for (auto const &[key, val] : entity_cache::proj_map)
+    Vector player_pos   = RAW_ENT(LOCAL_E)->GetAbsOrigin();
+    const int proj_size = entity_cache::proj_map.size();
+    for (int i = 0; i < proj_size; ++i)
     {
+        auto curr_tuple   = entity_cache::proj_map[i];
+        Vector key        = std::get<0>(curr_tuple);
+        CachedEntity *val = std::get<1>(curr_tuple);
         if (CE_GOOD(val))
         {
             // Since we are sending this warp next tick we need to compensate for fast moving projectiles
@@ -287,7 +291,7 @@ void dodgeProj()
                 if (trace.DidHit())
                 {
 
-                                       // We need to determine wether the projectile is coming in from the left or right of us so we don't warp into the projectile.
+                    // We need to determine wether the projectile is coming in from the left or right of us so we don't warp into the projectile.
                     Vector result = GetAimAtAngles(g_pLocalPlayer->v_Eye, RAW_ENT(val)->GetAbsOrigin(), LOCAL_E) - g_pLocalPlayer->v_OrigViewangles;
 
                     if (0 <= result.y)
@@ -296,9 +300,10 @@ void dodgeProj()
                         yaw_amount = 90.0f;
                     if ((IClientEntity *) trace.m_pEnt == RAW_ENT(LOCAL_E))
                     {
-                        was_hurt   = true;
-                        warp_dodge = true;
-                        entity_cache::proj_map.erase(key);
+                        was_hurt      = true;
+                        warp_dodge    = true;
+                        auto iterator = entity_cache::proj_map.begin() + i;
+                        entity_cache::proj_map.erase(iterator);
                     }
                 } // It didn't hit anything but it has been proven to be very close to us. Dodge. (This is for the huntsman+pills)
                 else
@@ -310,13 +315,15 @@ void dodgeProj()
                         yaw_amount = -90.0f;
                     else
                         yaw_amount = 90.0f;
-                    entity_cache::proj_map.erase(key);
+                    auto iterator = entity_cache::proj_map.begin() + i;
+                    entity_cache::proj_map.erase(iterator);
                 }
             }
         }
         else
         {
-            entity_cache::proj_map.erase(key);
+            auto iterator = entity_cache::proj_map.begin() + i;
+            entity_cache::proj_map.erase(iterator);
         }
     }
 }
@@ -798,9 +805,9 @@ void warpLogic()
                 // Find an entity meeting the Criteria and closest to crosshair
                 std::pair<CachedEntity *, float> result{ nullptr, FLT_MAX };
 
-                for (auto const &ent: entity_cache::player_cache)
+                for (auto const &ent : entity_cache::player_cache)
                 {
-                    
+
                     if (CE_BAD(ent) || !ent->m_bAlivePlayer() || !ent->m_bEnemy() || !player_tools::shouldTarget(ent))
                         continue;
                     // No hitboxes

--- a/src/hitrate.cpp
+++ b/src/hitrate.cpp
@@ -22,42 +22,48 @@ int count_hits_sniper{ 0 };
 int count_hits{ 0 };
 int count_hits_head{ 0 };
 
-CatCommand clear_hirate("debug_hitrate_clear", "Clear hitrate", []() {
-    count_shots       = 0;
-    count_hits        = 0;
-    count_hits_sniper = 0;
-    count_hits_head   = 0;
-});
+CatCommand clear_hirate("debug_hitrate_clear", "Clear hitrate",
+                        []()
+                        {
+                            count_shots       = 0;
+                            count_hits        = 0;
+                            count_hits_sniper = 0;
+                            count_hits_head   = 0;
+                        });
 
-CatCommand debug_hitrate("debug_hitrate", "Debug hitrate", []() {
-    int p1 = 0;
-    int p2 = 0;
-    if (count_shots)
-    {
-        p1 = float(count_hits) / float(count_shots) * 100.0f;
-    }
-    if (count_hits)
-    {
-        p2 = float(count_hits_head) / float(count_hits) * 100.0f;
-    }
-    logging::Info("%d / %d (%d%%)", count_hits, count_shots, p1);
-    logging::Info("%d / %d (%d%%)", count_hits_head, count_hits_sniper, p2);
-});
+CatCommand debug_hitrate("debug_hitrate", "Debug hitrate",
+                         []()
+                         {
+                             int p1 = 0;
+                             int p2 = 0;
+                             if (count_shots)
+                             {
+                                 p1 = float(count_hits) / float(count_shots) * 100.0f;
+                             }
+                             if (count_hits)
+                             {
+                                 p2 = float(count_hits_head) / float(count_hits) * 100.0f;
+                             }
+                             logging::Info("%d / %d (%d%%)", count_hits, count_shots, p1);
+                             logging::Info("%d / %d (%d%%)", count_hits_head, count_hits_sniper, p2);
+                         });
 
-CatCommand debug_ammo("debug_ammo", "Debug ammo", []() {
-    for (int i = 0; i < 4; i++)
-    {
-        logging::Info("%d %d", i, CE_INT(LOCAL_E, netvar.m_iAmmo + i * 4));
-    }
-});
+CatCommand debug_ammo("debug_ammo", "Debug ammo",
+                      []()
+                      {
+                          for (int i = 0; i < 4; i++)
+                          {
+                              logging::Info("%d %d", i, CE_INT(LOCAL_E, netvar.m_iAmmo + i * 4));
+                          }
+                      });
 
 // If this is true, Update() will consider increasing the brutenum soon if the shot was a miss
 bool resolve_soon[PLAYER_ARRAY_SIZE];
 std::array<Timer, PLAYER_ARRAY_SIZE> resolve_timer{};
 
-static int aimbot_target_idx   = -1;
-static bool aimbot_target_body = false;
-static Timer aimbot_shot{};
+int aimbot_target_idx   = 0;
+bool aimbot_target_body = false;
+Timer aimbot_shot{};
 
 void OnShot()
 {
@@ -103,7 +109,7 @@ void Update()
     {
 
         int ammo = CE_INT(LOCAL_E, netvar.m_iAmmo + 4);
-        if (ammo < lastammo && !aimbot_shot.check(500) && aimbot_target_idx != -1)
+        if (ammo < lastammo && !aimbot_shot.check(500) && !aimbot_target_idx)
             OnShot();
         lastammo = ammo;
         // Resolver
@@ -150,9 +156,11 @@ HurtListener &listener()
     return l;
 }
 
-InitRoutine init([]() {
-    g_IGameEventManager->AddListener(&listener(), false);
-    EC::Register(
-        EC::Shutdown, []() { g_IGameEventManager->RemoveListener(&listener()); }, "shutdown_hitrate");
-});
+InitRoutine init(
+    []()
+    {
+        g_IGameEventManager->AddListener(&listener(), false);
+        EC::Register(
+            EC::Shutdown, []() { g_IGameEventManager->RemoveListener(&listener()); }, "shutdown_hitrate");
+    });
 } // namespace hitrate

--- a/src/hooks/CreateMove.cpp
+++ b/src/hooks/CreateMove.cpp
@@ -132,12 +132,50 @@ void PrecalculateCanShoot()
 static int attackticks = 0;
 namespace hooked_methods
 {
+void speedHack(CUserCmd *cmd, bool &ret)
+{
+    float speed, yaw;
+    Vector vsilent, ang;
+    if (cmd->buttons & IN_DUCK && (CE_INT(g_pLocalPlayer->entity, netvar.iFlags) & FL_ONGROUND) && !(cmd->buttons & IN_ATTACK) && !HasCondition<TFCond_Charging>(LOCAL_E))
+    {
+        speed                     = Vector{ cmd->forwardmove, cmd->sidemove, 0.0f }.Length();
+        static float prevspeedang = 0.0f;
+        if (fabs(speed) > 0.0f)
+        {
+
+            if (forward_speedhack)
+            {
+                cmd->forwardmove *= -1.0f;
+                cmd->sidemove *= -1.0f;
+                cmd->viewangles.x = 91;
+            }
+            Vector vecMove(cmd->forwardmove, cmd->sidemove, 0.0f);
+
+            vecMove *= -1;
+            float flLength = vecMove.Length();
+            Vector angMoveReverse{};
+            VectorAngles(vecMove, angMoveReverse);
+            cmd->forwardmove = -flLength;
+            cmd->sidemove    = 0.0f; // Move only backwards, no sidemove
+            float res        = g_pLocalPlayer->v_OrigViewangles.y - angMoveReverse.y;
+            while (res > 180)
+                res -= 360;
+            while (res < -180)
+                res += 360;
+            if (res - prevspeedang > 90.0f)
+                res = (res + prevspeedang) / 2;
+            prevspeedang                     = res;
+            cmd->viewangles.y                = res;
+            cmd->viewangles.z                = 90.0f;
+            g_pLocalPlayer->bUseSilentAngles = true;
+        }
+    }
+}
 DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUserCmd *cmd)
 {
     g_Settings.is_create_move = true;
-    bool time_replaced, ret, speedapplied;
-    float curtime_old, servertime, speed, yaw;
-    Vector vsilent, ang;
+    bool time_replaced, ret;
+    float curtime_old, servertime;
 
     current_user_cmd = cmd;
     EC::run(EC::CreateMoveEarly);
@@ -219,9 +257,7 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
         time_replaced         = true;
     }
     if (g_Settings.bInvalid)
-    {
         entity_cache::Invalidate();
-    }
 
     //	PROF_BEGIN();
     // Do not update if in warp, since the entities will stay identical either way
@@ -252,7 +288,7 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
     }
     g_Settings.bInvalid = false;
 
-    if (CE_GOOD(g_pLocalPlayer->entity))
+    if (CE_GOOD(g_pLocalPlayer->entity) && g_pLocalPlayer->entity)
     {
         if (!g_pLocalPlayer->life_state && CE_GOOD(g_pLocalPlayer->weapon()))
         {
@@ -317,6 +353,8 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
                 projectile_logging::Update();
         }
     }
+    else
+        return false;
     {
         PROF_SECTION(CM_WRAPPER);
         EC::run(EC::CreateMove_NoEnginePred);
@@ -355,46 +393,15 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
 #endif
     if (CE_GOOD(g_pLocalPlayer->entity))
     {
-        speedapplied = false;
-        if (roll_speedhack && cmd->buttons & IN_DUCK && (CE_INT(g_pLocalPlayer->entity, netvar.iFlags) & FL_ONGROUND) && !(cmd->buttons & IN_ATTACK) && !HasCondition<TFCond_Charging>(LOCAL_E))
+        if (roll_speedhack)
+            speedHack(cmd, ret);
+        else
         {
-            speed                     = Vector{ cmd->forwardmove, cmd->sidemove, 0.0f }.Length();
-            static float prevspeedang = 0.0f;
-            if (fabs(speed) > 0.0f)
+            if (g_pLocalPlayer->bUseSilentAngles)
             {
 
-                if (forward_speedhack)
-                {
-                    cmd->forwardmove *= -1.0f;
-                    cmd->sidemove *= -1.0f;
-                    cmd->viewangles.x = 91;
-                }
-                Vector vecMove(cmd->forwardmove, cmd->sidemove, 0.0f);
-
-                vecMove *= -1;
-                float flLength = vecMove.Length();
-                Vector angMoveReverse{};
-                VectorAngles(vecMove, angMoveReverse);
-                cmd->forwardmove = -flLength;
-                cmd->sidemove    = 0.0f; // Move only backwards, no sidemove
-                float res        = g_pLocalPlayer->v_OrigViewangles.y - angMoveReverse.y;
-                while (res > 180)
-                    res -= 360;
-                while (res < -180)
-                    res += 360;
-                if (res - prevspeedang > 90.0f)
-                    res = (res + prevspeedang) / 2;
-                prevspeedang                     = res;
-                cmd->viewangles.y                = res;
-                cmd->viewangles.z                = 90.0f;
-                g_pLocalPlayer->bUseSilentAngles = true;
-                speedapplied                     = true;
-            }
-        }
-        if (g_pLocalPlayer->bUseSilentAngles)
-        {
-            if (!speedapplied)
-            {
+                float speed, yaw;
+                Vector ang, vsilent;
                 vsilent.x = cmd->forwardmove;
                 vsilent.y = cmd->sidemove;
                 vsilent.z = cmd->upmove;
@@ -406,9 +413,9 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
                 float clamped_pitch = fabsf(fmodf(cmd->viewangles.x, 360.0f));
                 if (clamped_pitch >= 90 && clamped_pitch <= 270)
                     cmd->forwardmove = -cmd->forwardmove;
-            }
 
-            ret = false;
+                ret = false;
+            }
         }
         g_pLocalPlayer->UpdateEnd();
     }

--- a/src/hooks/CreateMove.cpp
+++ b/src/hooks/CreateMove.cpp
@@ -15,7 +15,7 @@
 #include "NavBot.hpp"
 #include "HookTools.hpp"
 #include "teamroundtimer.hpp"
-#include <ESP.hpp>
+
 // Found in C_BasePlayer. It represents "m_pCurrentCommand"
 #define CURR_CUSERCMD_PTR 4452
 #include "HookedMethods.hpp"
@@ -258,10 +258,7 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
         time_replaced         = true;
     }
     if (g_Settings.bInvalid)
-    {
-        hacks::shared::esp::data.clear();
-        entity_cache::array.clear();
-    }
+        entity_cache::Invalidate();
     //	PROF_BEGIN();
     // Do not update if in warp, since the entities will stay identical either way
     if (!hacks::tf2::warp::in_warp)
@@ -362,7 +359,7 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
         PROF_SECTION(CM_WRAPPER);
         EC::run(EC::CreateMove_NoEnginePred);
 
-        if (engine_pred)
+        if (engine_pred && g_pLocalPlayer->weapon_mode == weapon_projectile)
         {
             engine_prediction::RunEnginePrediction(RAW_ENT(LOCAL_E), current_user_cmd);
             g_pLocalPlayer->UpdateEye();

--- a/src/hooks/CreateMove.cpp
+++ b/src/hooks/CreateMove.cpp
@@ -15,6 +15,7 @@
 #include "NavBot.hpp"
 #include "HookTools.hpp"
 #include "teamroundtimer.hpp"
+#include <ESP.hpp>
 // Found in C_BasePlayer. It represents "m_pCurrentCommand"
 #define CURR_CUSERCMD_PTR 4452
 #include "HookedMethods.hpp"
@@ -257,8 +258,10 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
         time_replaced         = true;
     }
     if (g_Settings.bInvalid)
-        entity_cache::Invalidate();
-
+    {
+        hacks::shared::esp::data.clear();
+        entity_cache::array.clear();
+    }
     //	PROF_BEGIN();
     // Do not update if in warp, since the entities will stay identical either way
     if (!hacks::tf2::warp::in_warp)

--- a/src/hooks/GetFriendPersonaName.cpp
+++ b/src/hooks/GetFriendPersonaName.cpp
@@ -37,9 +37,10 @@ bool StolenName()
     int potential_targets_length = 0;
 
     // Go through entities looking for potential targets
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
         // Check if ent is a good target
+        int i = ent->m_IDX;
         if (i == g_pLocalPlayer->entity_idx)
             continue;
         if (g_pPlayerResource->GetTeam(i) != g_pLocalPlayer->team)

--- a/src/hooks/LevelShutdown.cpp
+++ b/src/hooks/LevelShutdown.cpp
@@ -6,7 +6,7 @@
 #include <hacks/Aimbot.hpp>
 #include <hacks/hacklist.hpp>
 #include "HookedMethods.hpp"
-
+#include <ESP.hpp>
 namespace hooked_methods
 {
 
@@ -19,6 +19,7 @@ DEFINE_HOOKED_METHOD(LevelShutdown, void, void *this_)
     EC::run(EC::LevelShutdown);
     // Free memory for hitbox cache
     entity_cache::Shutdown();
+    hacks::shared::esp::Shutdown();
 #if ENABLE_IPC
     if (ipc::peer)
     {

--- a/src/hooks/Paint.cpp
+++ b/src/hooks/Paint.cpp
@@ -73,8 +73,6 @@ DEFINE_HOOKED_METHOD(Paint, void, IEngineVGui *this_, PaintMode_t mode)
         {
             PROF_SECTION(PT_command_stack);
             std::lock_guard<std::mutex> guard(hack::command_stack_mutex);
-            // logging::Info("executing %s",
-            //              hack::command_stack().top().c_str());
             g_IEngine->ClientCmd_Unrestricted(hack::command_stack().top().c_str());
             hack::command_stack().pop();
         }

--- a/src/hooks/visual/DrawModelExecute.cpp
+++ b/src/hooks/visual/DrawModelExecute.cpp
@@ -263,8 +263,10 @@ bool ShouldRenderChams(IClientEntity *entity)
     if (entity->entindex() < 0)
         return false;
     CachedEntity *ent = ENTITY(entity->entindex());
-    if (ent->m_IDX == LOCAL_E->m_IDX)
+    if (ent && LOCAL_E && ent->m_IDX == LOCAL_E->m_IDX)
         return *chamsself;
+    else
+        return false;
     switch (ent->m_Type())
     {
     case ENTITY_BUILDING:

--- a/src/hooks/visual/FrameStageNotify.cpp
+++ b/src/hooks/visual/FrameStageNotify.cpp
@@ -62,13 +62,13 @@ DEFINE_HOOKED_METHOD(FrameStageNotify, void, void *this_, ClientFrameStage_t sta
                     continue;
                 // Don't override this stuff
                 bool good = true;
-                for (auto &entry : dont_override_strings)
+                for (auto const &entry : dont_override_strings)
                     if (path.find(entry) != path.npos)
                     {
                         good = false;
                     }
                 // Don't draw this stuff
-                for (auto &entry : nodraw_strings)
+                for (auto const &entry : nodraw_strings)
                     if (path.find(entry) != path.npos)
                     {
                         pMaterial->SetMaterialVarFlag(MATERIAL_VAR_NO_DRAW, true);
@@ -111,15 +111,15 @@ DEFINE_HOOKED_METHOD(FrameStageNotify, void, void *this_, ClientFrameStage_t sta
             int should_filter = 0;
             auto name         = std::string(pMaterial->GetTextureGroupName());
 
-            for (auto &entry : gui_strings)
+            for (auto const &entry : gui_strings)
                 if (name.find(entry) != name.npos)
                     should_filter = 1;
 
-            for (auto &entry : world_strings)
+            for (auto const &entry : world_strings)
                 if (name.find(entry) != name.npos)
                     should_filter = 2;
 
-            for (auto &entry : skybox_strings)
+            for (auto const &entry : skybox_strings)
                 if (name.find(entry) != name.npos)
                     should_filter = 3;
 

--- a/src/hoovy.cpp
+++ b/src/hoovy.cpp
@@ -41,12 +41,9 @@ void UpdateHoovyList()
     if (CE_BAD(LOCAL_E))
         return;
 
-    static CachedEntity *ent;
-    for (int i = 1; i <= MAX_PLAYERS; i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        ent = ENTITY(i);
-        if (CE_GOOD(ent) && CE_BYTE(ent, netvar.iLifeState) == LIFE_ALIVE)
-        {
+            int i = ent->m_IDX;
             if (!hoovy_list[i - 1])
             {
                 if (IsHoovyHelper(ent))
@@ -57,7 +54,7 @@ void UpdateHoovyList()
                 if (!HasSandvichOut(ent))
                     hoovy_list[i - 1] = false;
             }
-        }
+        
     }
 }
 

--- a/src/localplayer.cpp
+++ b/src/localplayer.cpp
@@ -89,7 +89,7 @@ void LocalPlayer::Update()
 
     entity_idx = g_IEngine->GetLocalPlayer();
     entity     = ENTITY(entity_idx);
-    if (CE_BAD(entity))
+    if (!entity || CE_BAD(entity))
     {
         team = 0;
         return;
@@ -100,7 +100,7 @@ void LocalPlayer::Update()
     bRevving                 = false;
     bRevved                  = false;
     wep                      = weapon();
-    if (CE_GOOD(wep))
+    if (wep && CE_GOOD(wep))
     {
         weapon_mode = GetWeaponModeloc();
         if (wep->m_iClassID() == CL_CLASS(CTFSniperRifle) || wep->m_iClassID() == CL_CLASS(CTFSniperRifleDecap))
@@ -152,10 +152,10 @@ void LocalPlayer::Update()
     if (!life_state)
     {
         spectator_state = NONE;
-        for (int i = 0; i < PLAYER_ARRAY_SIZE; i++)
+        for (auto const &ent: entity_cache::player_cache)
         {
             // Assign the for loops tick number to an ent
-            CachedEntity *ent = ENTITY(i);
+            
             if (!CE_BAD(ent) && (HandleToIDX(CE_INT(ent, netvar.hObserverTarget))) == LOCAL_E->m_IDX)
             {
                 auto mode = CE_INT(ent, netvar.iObserverMode);

--- a/src/navparser.cpp
+++ b/src/navparser.cpp
@@ -221,7 +221,7 @@ public:
             // If the extern blacklist is running, ensure we don't try to use a bad area
             bool is_blacklisted = false;
             if (!free_blacklist_blocked)
-                for (auto &entry : free_blacklist)
+                for (auto const &entry : free_blacklist)
                 {
                     if (entry.first == connection.area)
                     {
@@ -354,7 +354,7 @@ public:
         // Find sentries and stickies
         for (int i = g_IEngine->GetMaxClients() + 1; i < MAX_ENTITIES; i++)
         {
-            CachedEntity *ent = ENTITY(i);
+            CachedEntity* ent = ENTITY(i);
             if (CE_INVALID(ent) || !ent->m_bAlivePlayer() || ent->m_iTeam() == g_pLocalPlayer->team)
                 continue;
             bool is_sentry = ent->m_iClassID() == CL_CLASS(CObjectSentrygun);
@@ -630,7 +630,7 @@ static void followCrumbs()
         fall_vec.erase(fall_vec.begin());
 
     bool reset_z = true;
-    for (auto &entry : fall_vec)
+    for (auto const &entry : fall_vec)
     {
         if (!(entry <= 0.01f && entry >= -0.01f))
             reset_z = false;
@@ -800,7 +800,7 @@ void checkBlacklist()
         return;
     }
     CNavArea *local_area = map->findClosestNavSquare(g_pLocalPlayer->v_Origin);
-    for (auto &entry : map->free_blacklist)
+    for (auto const &entry : map->free_blacklist)
     {
         // Local player is in a blocked area, so temporarily remove the blacklist as else we would be stuck
         if (entry.first == local_area)
@@ -820,7 +820,7 @@ void checkBlacklist()
         if (should_abandon)
             break;
         // A path Node is blacklisted, abandon pathing
-        for (auto &entry : map->free_blacklist)
+        for (auto const &entry : map->free_blacklist)
         {
             if (entry.first == crumb.navarea)
                 should_abandon = true;
@@ -932,7 +932,7 @@ std::unordered_map<CNavArea *, BlacklistReason> *getFreeBlacklist()
 std::unordered_map<CNavArea *, BlacklistReason> getFreeBlacklist(BlacklistReason reason)
 {
     std::unordered_map<CNavArea *, BlacklistReason> return_map;
-    for (auto &entry : map->free_blacklist)
+    for (auto const &entry : map->free_blacklist)
     {
         // Category matches
         if (entry.second.value == reason.value)

--- a/src/payloadcontroller.cpp
+++ b/src/payloadcontroller.cpp
@@ -14,10 +14,10 @@ void Update()
     if (update_payloads.test_and_set(3000))
     {
         // Reset entries
-        for (auto &entry : payloads)
+        for (auto const &entry : payloads)
             entry.clear();
 
-        for (auto &ent : entity_cache::valid_ents)
+        for (auto const &ent : entity_cache::valid_ents)
         {
             // Not the object we need or invalid (team)
             if (ent->m_iClassID() != CL_CLASS(CObjectCartDispenser) || ent->m_iTeam() < TEAM_RED || ent->m_iTeam() > TEAM_BLU)
@@ -57,7 +57,7 @@ std::optional<Vector> getClosestPayload(Vector source, int team)
 
 void LevelInit()
 {
-    for (auto &entry : payloads)
+    for (auto const &entry : payloads)
         entry.clear();
 }
 

--- a/src/playerlist.cpp
+++ b/src/playerlist.cpp
@@ -258,7 +258,7 @@ CatCommand pl_print("pl_print", "Print current player list",
                             if (!include_all && !std::memcmp(&it->second, &empty, sizeof(empty)))
                                 continue;
 
-                            const auto &ent = it->second;
+                            auto const &ent = it->second;
 #if ENABLE_VISUALS
                             logging::Info("%u -> %d (%f,%f,%f,%f) %f %u %u", it->first, ent.state, ent.color.r, ent.color.g, ent.color.b, ent.color.a, ent.inventory_value, ent.deaths_to, ent.kills);
 #else

--- a/src/playerresource.cpp
+++ b/src/playerresource.cpp
@@ -11,8 +11,6 @@
 
 void TFPlayerResource::Update()
 {
-    IClientEntity *ent;
-
     entity = 0;
     for (auto const &ent_not_raw : entity_cache::valid_ents)
     {

--- a/src/playerresource.cpp
+++ b/src/playerresource.cpp
@@ -14,7 +14,7 @@ void TFPlayerResource::Update()
     IClientEntity *ent;
 
     entity = 0;
-    for (auto &ent_not_raw : entity_cache::valid_ents)
+    for (auto const &ent_not_raw : entity_cache::valid_ents)
     {
         auto ent = RAW_ENT(ent_not_raw);
         if (ent && ent->GetClientClass()->m_ClassID == RCC_PLAYERRESOURCE)
@@ -32,7 +32,7 @@ int TFPlayerResource::GetHealth(CachedEntity *player)
     /* :thinking */
     IF_GAME(!IsTF()) return 100;
     ent = g_IEntityList->GetClientEntity(entity);
-    if (!ent || ent->GetClientClass()->m_ClassID != RCC_PLAYERRESOURCE)
+    if (!ent || ent->GetClientClass()->m_ClassID != RCC_PLAYERRESOURCE || !player)
         return 0;
     idx = player->m_IDX;
     if (idx >= 64 || idx < 0)
@@ -47,7 +47,7 @@ int TFPlayerResource::GetMaxHealth(CachedEntity *player)
     /* :thinking */
     IF_GAME(!IsTF()) return 100;
     ent = g_IEntityList->GetClientEntity(entity);
-    if (!ent || ent->GetClientClass()->m_ClassID != RCC_PLAYERRESOURCE)
+    if (!ent || ent->GetClientClass()->m_ClassID != RCC_PLAYERRESOURCE || !player)
         return 0;
     idx = player->m_IDX;
     if (idx >= 64 || idx < 0)
@@ -62,7 +62,7 @@ int TFPlayerResource::GetMaxBuffedHealth(CachedEntity *player)
 
     IF_GAME(!IsTF()) return GetMaxHealth(player);
     ent = g_IEntityList->GetClientEntity(entity);
-    if (!ent || ent->GetClientClass()->m_ClassID != RCC_PLAYERRESOURCE)
+    if (!ent || ent->GetClientClass()->m_ClassID != RCC_PLAYERRESOURCE || !player)
         return 0;
     idx = player->m_IDX;
     if (idx >= 64 || idx < 0)

--- a/src/prediction.cpp
+++ b/src/prediction.cpp
@@ -317,9 +317,9 @@ void Prediction_PaintTraverse()
                 return;
         }
 
-        for (int i = 1; i < g_GlobalVars->maxClients; i++)
+        for (auto const &ent : entity_cache::player_cache)
         {
-            auto ent = ENTITY(i);
+            
             if (CE_BAD(ent) || !ent->m_bAlivePlayer())
                 continue;
 
@@ -529,7 +529,6 @@ std::pair<Vector, Vector> ProjectilePrediction_Engine(CachedEntity *ent, int hb,
     Vector current_velocity = velocity;
     int maxsteps            = (int) debug_pp_steps;
     float steplength        = g_GlobalVars->interval_per_tick;
-    bool has_run_before     = false;
     for (int steps = 0; steps < maxsteps; steps++, currenttime += steplength)
     {
         ent->m_vecOrigin()                                 = current;
@@ -733,10 +732,10 @@ static InitRoutine init(
                 // Don't run if we don't use it
                 if (!hacks::shared::aimbot::engine_projpred && !debug_pp_draw)
                     return;
-                for (int i = 1; i < g_GlobalVars->maxClients; i++)
+                for (auto const &ent: entity_cache::player_cache)
                 {
-                    auto ent     = ENTITY(i);
-                    auto &buffer = previous_positions.at(i - 1);
+                    
+                    auto &buffer = previous_positions.at(ent->m_IDX - 1);
 
                     if (CE_BAD(LOCAL_E) || CE_BAD(ent) || !ent->m_bAlivePlayer())
                     {

--- a/src/projlogging.cpp
+++ b/src/projlogging.cpp
@@ -14,7 +14,7 @@ Vector prevloc[2048]{};
 
 void Update()
 {
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
 
         const model_t *model    = RAW_ENT(ent)->GetModel();

--- a/src/sdk/setup_bones.cpp
+++ b/src/sdk/setup_bones.cpp
@@ -2648,16 +2648,13 @@ bool Studio_SolveIK(int iThigh, int iKnee, int iFoot, Vector &targetFoot, Vector
 
     // debugLine( worldKnee, worldThigh + ikTargetKnee, 0, 0, 255, true, 0 );
 
-    int color[3] = { 0, 255, 0 };
+   
 
     // too far away? (0.9998 is about 1 degree)
     if (ikFoot.Length() > (l1 + l2) * KNEEMAX_EPSILON)
     {
         VectorNormalize(ikFoot);
         VectorScale(ikFoot, (l1 + l2) * KNEEMAX_EPSILON, ikFoot);
-        color[0] = 255;
-        color[1] = 0;
-        color[2] = 0;
     }
 
     // too close?
@@ -3210,7 +3207,6 @@ void CIKContext::AddAutoplayLocks(Vector pos[], Quaternion q[])
         // save off current knee direction
         if (pchain->pLink(0)->kneeDir.LengthSqr() > 0.0)
         {
-            Vector tmp = pchain->pLink(0)->kneeDir;
             VectorRotate(pchain->pLink(0)->kneeDir, boneToWorld[pchain->pLink(0)->bone], ikrule.kneeDir);
             MatrixPosition(boneToWorld[pchain->pLink(1)->bone], ikrule.kneePos);
         }
@@ -4142,7 +4138,7 @@ void CIKContext::AddAllLocks(Vector pos[], Quaternion q[])
         // save off current knee direction
         if (pchain->pLink(0)->kneeDir.LengthSqr() > 0.0)
         {
-            Vector tmp = pchain->pLink(0)->kneeDir;
+          
             VectorRotate(pchain->pLink(0)->kneeDir, boneToWorld[pchain->pLink(0)->bone], ikrule.kneeDir);
             MatrixPosition(boneToWorld[pchain->pLink(1)->bone], ikrule.kneePos);
         }

--- a/src/teamroundtimer.cpp
+++ b/src/teamroundtimer.cpp
@@ -25,7 +25,7 @@ void CTeamRoundTimer::Update()
     IClientEntity *ent;
 
     entity = 0;
-    for (auto &ent : entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
         auto result_ent = ent->InternalEntity();
         if (ent && result_ent->GetClientClass()->m_ClassID == CL_CLASS(CTeamRoundTimer))

--- a/src/teamroundtimer.cpp
+++ b/src/teamroundtimer.cpp
@@ -22,7 +22,6 @@ round_states CTeamRoundTimer::GetRoundState()
 
 void CTeamRoundTimer::Update()
 {
-    IClientEntity *ent;
 
     entity = 0;
     for (auto const &ent : entity_cache::valid_ents)

--- a/src/trace.cpp
+++ b/src/trace.cpp
@@ -64,7 +64,7 @@ bool trace::FilterDefault::ShouldHitEntity(IHandleEntity *handle, int mask)
                     {
                         auto weapon = ENTITY(weapon_idx);
                         // If holding sniper rifle
-                        if (weapon->m_iClassID() == CL_CLASS(CTFSniperRifle) || weapon->m_iClassID() == CL_CLASS(CTFSniperRifleDecap))
+                        if (!weapon || weapon->m_iClassID() == CL_CLASS(CTFSniperRifle) || weapon->m_iClassID() == CL_CLASS(CTFSniperRifleDecap))
                             return false;
                     }
                 }

--- a/src/visual/EffectGlow.cpp
+++ b/src/visual/EffectGlow.cpp
@@ -458,14 +458,13 @@ void EffectGlow::Render(int x, int y, int w, int h)
     if (!isHackActive() || (clean_screenshots && g_IEngine->IsTakingScreenshot()) || g_Settings.bInvalid || disable_visuals)
         return;
     static ITexture *orig;
-    static IClientEntity *ent;
     static IMaterialVar *blury_bloomamount;
     if (!init)
         Init();
     CMatRenderContextPtr ptr(GET_RENDER_CONTEXT);
     orig = ptr->GetRenderTarget();
     BeginRenderGlow();
-    for (auto &ent_non_raw : entity_cache::valid_ents)
+    for (auto const &ent_non_raw : entity_cache::valid_ents)
     {
         auto ent = RAW_ENT(ent_non_raw);
         if (ent && ShouldRenderGlow(ent))

--- a/src/visual/drawmgr.cpp
+++ b/src/visual/drawmgr.cpp
@@ -60,7 +60,6 @@ void BeginCheatVisuals()
     ResetStrings();
 }
 
-std::mutex drawing_mutex;
 
 double getRandom(double lower_bound, double upper_bound)
 {

--- a/src/visual/imgui/imgui_impl.cpp
+++ b/src/visual/imgui/imgui_impl.cpp
@@ -198,8 +198,6 @@ bool ImGui_ImplSdl_ProcessEvent(SDL_Event *event)
 
 bool ImGui_Impl_CreateFontsTexture(ImFontAtlas *font)
 {
-    // Build texture atlas
-    ImGuiIO &io = ImGui::GetIO();
     unsigned char *pixels;
     int width, height;
     font->GetTexDataAsRGBA32(&pixels, &width,

--- a/src/votelogger.cpp
+++ b/src/votelogger.cpp
@@ -38,11 +38,10 @@ static void vote_rage_back()
     if (!g_IEngine->IsInGame() || !attempt_vote_time.test_and_set(1000))
         return;
 
-    for (int i = 1; i <= g_IEngine->GetMaxClients(); i++)
+    for (auto const &ent: entity_cache::player_cache)
     {
-        auto ent = ENTITY(i);
         // TO DO: m_bEnemy check only when you can't vote off players from the opposite team
-        if (CE_BAD(ent) || ent == LOCAL_E || ent->m_Type() != ENTITY_PLAYER || ent->m_bEnemy())
+        if (ent == LOCAL_E || ent->m_bEnemy())
             continue;
 
         if (!GetPlayerInfo(ent->m_IDX, &info))
@@ -87,7 +86,6 @@ void dispatchUserMessage(bf_read &buffer, int type)
     {
         // TODO: Add always vote no/vote no on friends. Cvar is "vote option2"
         was_local_player = false;
-        int team         = buffer.ReadByte();
         int vote_id      = buffer.ReadLong();
         int caller       = buffer.ReadByte();
         char reason[64];


### PR DESCRIPTION
Projectile dodging, detects if a projectile is coming near you and warps to dodge. 
ESP fixes, bonestruct was an absolute mess and needed to be fixed.
Removed the HUGE arrays for entity cache. We only use a fraction of the max and it's more efficient to use hashmaps. Removed the Aimbotdata array because we overwrite literally all the data in the array everytime. It can just be a single struct. 
Removed the hitbox cache array. It's never used as an array, and should just be contained within a cached entity.
Added player_cache, many loops use the exact same conditions for looping over valid players. 
Made the range-based for loops over entities constant where applicable. 
Made speedhack in createmove it's own function. It's rarely used and is pretty long. 
Removed the odd unused variable 
Fixed major hitrate bug
Fixed recent offset change