### PR TITLE
Bugfixes + small changes

### DIFF
--- a/data/menu/nullifiedcat/debug.xml
+++ b/data/menu/nullifiedcat/debug.xml
@@ -3,7 +3,6 @@
         <List width="200">
             <AutoVariable width="fill" target="debug.cursor-fix" label="Cursor fix"/>
             <AutoVariable width="fill" target="debug.engine-pred-others" label="Engine pred others"/>
-            <AutoVariable width="fill" target="debug.fast-vischeck" label="Fast vischeck"/>
             <AutoVariable width="fill" target="debug.join-wait-time" label="Joinspam wait time"/>
             <AutoVariable width="fill" target="debug.log-dispatch-user-msg" label="Log dispatched user messages"/>
             <AutoVariable width="fill" target="debug.log-sent-chat" label="Log sent chat"/>

--- a/data/menu/nullifiedcat/hackinfo.xml
+++ b/data/menu/nullifiedcat/hackinfo.xml
@@ -4,7 +4,6 @@
             <AutoVariable width="fill" target="misc.debug-info" label="Debug"/>
             <AutoVariable width="fill" target="hack.log-console" label="Log debug info"/>
             <AutoVariable width="fill" target="debug.engine-pred-others" label="Engine pred others"/>
-            <AutoVariable width="fill" target="debug.fast-vischeck" label="Fast vischeck"/>
             <AutoVariable width="fill" target="debug.join-wait-time" label="Joinspam wait time"/>
             <AutoVariable width="fill" target="debug.log-dispatch-user-msg" label="Log dispatched user messages"/>
             <AutoVariable width="fill" target="debug.log-sent-chat" label="Log sent chat"/>

--- a/include/angles.hpp
+++ b/include/angles.hpp
@@ -27,6 +27,4 @@ struct angle_data_s
 extern angle_data_s data_[PLAYER_ARRAY_SIZE];
 
 void Update();
-angle_data_s &data_idx(int index);
-angle_data_s &data(const CachedEntity *entity);
 } // namespace angles

--- a/include/hacks/Spam.hpp
+++ b/include/hacks/Spam.hpp
@@ -23,6 +23,4 @@ extern const std::vector<std::string> builtin_lithium;
 
 bool isActive();
 void init();
-void createMove();
-void reload();
 } // namespace hacks::shared::spam

--- a/include/hacks/Trigger.hpp
+++ b/include/hacks/Trigger.hpp
@@ -12,8 +12,6 @@
 
 namespace hacks::shared::triggerbot
 {
-
-void CreateMove();
 bool ShouldShoot();
 bool IsTargetStateGood(CachedEntity *entity, std::optional<tf2::backtrack::BacktrackData> bt_data = std::nullopt);
 CachedEntity *FindEntInSight(float range, bool no_players = false);

--- a/include/hooks/HookTools.hpp
+++ b/include/hooks/HookTools.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "core/profiler.hpp"
-#include "functional"
 #include <array>
 
 namespace EC
@@ -43,7 +42,7 @@ enum ec_priority
     very_late
 };
 
-typedef std::function<void()> EventFunction;
+typedef void (*EventFunction)();
 void Register(enum ec_types type, const EventFunction &function, const std::string &name, enum ec_priority priority = average);
 void Unregister(enum ec_types type, const std::string &name);
 void run(enum ec_types type);

--- a/include/reclasses/C_TFWeaponBase.hpp
+++ b/include/reclasses/C_TFWeaponBase.hpp
@@ -84,10 +84,8 @@ public:
     }
     inline static float ApplyFireDelay(IClientEntity *self, float delay)
     {
-        typedef float (*ApplyFireDelay_t)(IClientEntity *, float);
-        static auto signature                     = gSignatures.GetClientSignature("55 89 E5 57 56 53 83 EC 6C C7 45 ? 00 00 00 00 A1 ? ? ? ? C7 45 ? 00 00 00 00 8B 5D ? 85 C0 0F 84 ? ? ? ? 8D 55 ? 89 04 24 31 F6 89 54 24 ? C7 44 24 ? ? ? ? ? C7 44 24 ? ? ? ? ? C7 44 24 ? ? ? ? ? C7 44 24 ? ? ? ? ? C7 44 24 ? 6B 00 00 00 C7 44 24 ? ? ? ? ? C7 44 24 ? 00 00 00 00 C7 44 24 ? 00 00 00 00 C7 44 24 ? 00 00 00 00 C7 44 24 ? 00 00 00 00 FF 50 ? A1 ? ? ? ? 8B 3D ? ? ? ? 8B 55 ? 89 45 ? 8B 45 ? 85 FF 89 55 ? 89 45 ? 0F 85 ? ? ? ? 85 DB 0F 84 ? ? ? ? 8B 7B ? 85 FF 0F 84 ? ? ? ? C7 04 24 ? ? ? ? E8 ? ? ? ? 89 45 ? 8B 07 89 3C 24 FF 10 8B 7D ? 8B 10 C7 44 24 ? 00 00 00 00 89 5C 24 ? C7 44 24 ? 00 00 80 3F 89 7C 24 ? 89 04 24 FF 52 ? D9 5D ? F3 0F 10 45 ? F3 0F 11 04 24 E8 ? ? ? ? D9 5D");
-        static ApplyFireDelay_t ApplyFireDelay_fn = (ApplyFireDelay_t) signature;
-        return ApplyFireDelay_fn(self, delay);
+        typedef float (*fn_t)(IClientEntity *, float);
+        return vfunc<fn_t>(self, offsets::PlatformOffset(478, offsets::undefined, 478), 0)(self, delay);;
     }
     inline static void AddToCritBucket(IClientEntity *self, float value)
     {

--- a/src/CaptureLogic.cpp
+++ b/src/CaptureLogic.cpp
@@ -215,7 +215,7 @@ void LevelInit()
 namespace cpcontroller
 {
 
-std::array<cp_info, MAX_CONTROL_POINTS> controlpoint_data;
+std::array<cp_info, MAX_CONTROL_POINTS+1> controlpoint_data;
 CachedEntity *objective_resource = nullptr;
 
 struct point_ignore
@@ -376,11 +376,11 @@ void UpdateControlPoints()
     // Clear the invalid controlpoints
     if (num_cp <= MAX_CONTROL_POINTS)
         for (int i = num_cp; i < MAX_CONTROL_POINTS; i++)
-            controlpoint_data.at(i) = cp_info();
+            controlpoint_data[i] = cp_info();
 
     for (int i = 0; i < num_cp; i++)
     {
-        auto &data    = controlpoint_data.at(i);
+        auto &data    = controlpoint_data[i];
         data.cp_index = i;
 
         // Update position (m_vCPPositions[index])
@@ -390,7 +390,7 @@ void UpdateControlPoints()
     if (capstatus_update.test_and_set(1000))
         for (int i = 0; i < num_cp; i++)
         {
-            auto &data = controlpoint_data.at(i);
+            auto &data = controlpoint_data[i];
             // Check accessibility for both teams, requires alot of checks
             data.can_cap.at(0) = isPointUseable(i, TEAM_RED);
             data.can_cap.at(1) = isPointUseable(i, TEAM_BLU);
@@ -470,7 +470,7 @@ void Update()
 } // namespace cpcontroller
 
 // Main handlers
-void CreateMove()
+static void CreateMove()
 {
     flagcontroller::Update();
     plcontroller::Update();

--- a/src/angles.cpp
+++ b/src/angles.cpp
@@ -69,44 +69,18 @@ float angle_data_s::deviation(int steps) const
     return sqrt(hx * hx + hy * hy);
 }
 
-angle_data_s &data_idx(int index)
-{
-    if (index < 1 || index > MAX_PLAYERS)
-    {
-        throw std::out_of_range("Angle table entity index out of range");
-    }
-    return data_[index];
-}
-
-angle_data_s &data(const CachedEntity *entity)
-{
-    return data_idx(entity->m_IDX);
-}
-
 void Update()
 {
     for (auto const &ent : entity_cache::player_cache)
     {
-        auto &d = data_idx(ent->m_IDX);
-
-        if (CE_GOOD(ent) && !CE_BYTE(ent, netvar.iLifeState))
+        auto &d = data_[ent->m_IDX];
+        if (ent->m_IDX == g_IEngine->GetLocalPlayer())
         {
-            if (!d.good)
-            {
-                memset(&d, 0, sizeof(angle_data_s));
-            }
-            if (ent->m_IDX == g_IEngine->GetLocalPlayer())
-            {
-                d.push(current_user_cmd->viewangles);
-            }
-            else
-            {
-                d.push(CE_VECTOR(ent, netvar.m_angEyeAngles));
-            }
+            d.push(current_user_cmd->viewangles);
         }
         else
         {
-            d.good = false;
+            d.push(CE_VECTOR(ent, netvar.m_angEyeAngles));
         }
     }
 }

--- a/src/crits.cpp
+++ b/src/crits.cpp
@@ -653,7 +653,7 @@ bool isExploitingDoubleAttack()
 }
 
 // Damage this round
-void CreateMove()
+static void CreateMove()
 {
     // It should never go down, if it does we need to compensate for it
     if (g_pPlayerResource->GetDamage(g_pLocalPlayer->entity_idx) < round_damage)

--- a/src/entityhitboxcache.cpp
+++ b/src/entityhitboxcache.cpp
@@ -78,8 +78,6 @@ void EntityHitboxCache::UpdateBones()
     // Do not run for bad ents/non player ents
     if (!m_bInit)
         Init();
-    if (CE_BAD(parent_ref) || parent_ref->m_Type() != ENTITY_PLAYER)
-        return;
     auto bone_ptr = GetBones();
     if (!bone_ptr || bones.empty())
         return;

--- a/src/hacks/AntiBackstab.cpp
+++ b/src/hacks/AntiBackstab.cpp
@@ -101,7 +101,7 @@ CachedEntity *ClosestSpy()
     return closest;
 }
 
-void CreateMove()
+static void CreateMove()
 {
     CachedEntity *spy;
     Vector diff;

--- a/src/hacks/AntiCheat.cpp
+++ b/src/hacks/AntiCheat.cpp
@@ -46,7 +46,7 @@ void SetRage(player_info_t info)
         playerlist::ChangeState(info.friendsID, playerlist::k_EState::RAGE);
 }
 
-void CreateMove()
+static void CreateMove()
 {
     if (!enable)
         return;

--- a/src/hacks/AntiCheatBypass.cpp
+++ b/src/hacks/AntiCheatBypass.cpp
@@ -38,7 +38,7 @@ bool CanSetCmdNum(int new_cmdnum)
     return true;
 }
 
-void CreateMoveLate()
+static void CreateMoveLate()
 {
     if (!enabled)
         return;

--- a/src/hacks/AutoBackstab.cpp
+++ b/src/hacks/AutoBackstab.cpp
@@ -397,7 +397,7 @@ inline bool HasKnife()
     return false;
 }
 
-void CreateMove()
+static void CreateMove()
 {
     if (!enabled)
         return;

--- a/src/hacks/AutoDetonator.cpp
+++ b/src/hacks/AutoDetonator.cpp
@@ -73,7 +73,7 @@ bool IsTarget(CachedEntity *ent)
 }
 
 // Function called by game for movement
-void CreateMove()
+static void CreateMove()
 {
     // Check if it enabled in settings, weapon entity exists and current
     // class is pyro

--- a/src/hacks/AutoHeal.cpp
+++ b/src/hacks/AutoHeal.cpp
@@ -590,7 +590,7 @@ int BestTarget()
     return best;
 }
 
-void CreateMove()
+static void CreateMove()
 {
     if (CE_BAD(LOCAL_W))
         return;

--- a/src/hacks/AutoItem.cpp
+++ b/src/hacks/AutoItem.cpp
@@ -332,7 +332,7 @@ void getAndEquipWeapon(std::string str, int clazz, int slot)
 }
 
 static Timer t{};
-void CreateMove()
+static void CreateMove()
 {
     if (!enable || CE_BAD(LOCAL_E) || !t.test_and_set(*interval))
         return;

--- a/src/hacks/AutoReflect.cpp
+++ b/src/hacks/AutoReflect.cpp
@@ -130,7 +130,7 @@ static bool ShouldReflect(CachedEntity *ent)
 }
 
 // Function called by game for movement
-void CreateMove()
+static void CreateMove()
 {
     // Check if user settings allow Auto Reflect
     if (!enable || CE_BAD(LOCAL_W) || (blastkey && !blastkey.isKeyDown()))

--- a/src/hacks/AutoSticky.cpp
+++ b/src/hacks/AutoSticky.cpp
@@ -93,7 +93,7 @@ bool IsTarget(CachedEntity *ent)
 }
 
 static int wait_ticks = 0;
-void CreateMove()
+static void CreateMove()
 {
     // Check user settings if auto-sticky is enabled
     if (!enable)

--- a/src/hacks/AutoViewmodel.cpp
+++ b/src/hacks/AutoViewmodel.cpp
@@ -5,7 +5,7 @@ namespace hacks::tf2::autoviewmodel
 
 static settings::Boolean auto_viewmodel_flipper{ "misc.auto-flip-viewmodel", "false" };
 
-void CreateMove()
+static void CreateMove()
 {
     if (!auto_viewmodel_flipper)
         return;

--- a/src/hacks/Backtrack.cpp
+++ b/src/hacks/Backtrack.cpp
@@ -255,7 +255,7 @@ void RestoreEntity(int entidx)
     set_data = std::nullopt;
 }
 
-void CreateMoveEarly()
+static void CreateMoveEarly()
 {
     if (hacks::tf2::antianticheat::enabled && *latency > 200.0f)
         latency = 200.0f;
@@ -327,7 +327,7 @@ void CreateMoveEarly()
     }
 }
 
-void CreateMoveLate()
+static void CreateMoveLate()
 {
     if (!isBacktrackEnabled)
         return;

--- a/src/hacks/BulletTracers.cpp
+++ b/src/hacks/BulletTracers.cpp
@@ -2,7 +2,7 @@
  * Credits  To Unknown For most of this
  */
 #include "common.hpp"
-
+#include "boost/unordered/unordered_flat_map.hpp"
 namespace hacks::tf2::bullettracers
 {
 
@@ -224,7 +224,7 @@ typedef void (*FX_Tracer_t)(Vector &, Vector &, int, bool);
 
 FX_Tracer_t FX_Tracer_fn;
 
-char SentryTracerParity[MAX_ENTITIES + 1]{ 0 };
+boost::unordered_flat_map<u_int16_t, char> SentryTracerParity;
 void FX_Tracer_detour(Vector &start, CEffectData &data, int velocity, bool makeWhiz)
 {
     // start and end are reversed, justvalvethings.club
@@ -239,8 +239,9 @@ void FX_Tracer_detour(Vector &start, CEffectData &data, int velocity, bool makeW
     CEffectData dataTracer;
     if (NET_INT(sentry, netvar.iUpgradeLevel) > 1)
     {
-        auto &parity = SentryTracerParity[sentry->entindex()];
-        parity       = !parity;
+        u_int16_t index = sentry->entindex();
+        auto &parity    = SentryTracerParity[index];
+        parity          = !parity;
         vfunc<GetAttachment_t>(sentry, 113, 0)(sentry, parity ? muzzle_l : muzzle_r, dataTracer.m_vStart);
     }
     else

--- a/src/hacks/ESP.cpp
+++ b/src/hacks/ESP.cpp
@@ -877,7 +877,7 @@ void ProcessEntityPT()
         // Check if entity is on screen, then save screen position if true
         auto position = ent->m_vecDormantOrigin();
         if (!position)
-            return;
+            continue;
 
         // Sightline esp
         if (sightlines && type == ENTITY_PLAYER)

--- a/src/hacks/MVMTools.cpp
+++ b/src/hacks/MVMTools.cpp
@@ -8,7 +8,7 @@ static settings::Boolean auto_f4("mvmtools.auto-f4", "false");
 static Timer revive_timer{};
 static Timer ready_timer{};
 
-void CreateMove()
+static void CreateMove()
 {
     if (CE_INVALID(LOCAL_E))
         return;

--- a/src/hacks/Misc.cpp
+++ b/src/hacks/Misc.cpp
@@ -202,7 +202,7 @@ static float angleDiffRad(float a1, float a2) noexcept
     return delta;
 }
 
-void CreateMove()
+static void CreateMove()
 {
 #if ENABLE_VISUALS
     if (misc_drawhitboxes)

--- a/src/hacks/MiscAimbot.cpp
+++ b/src/hacks/MiscAimbot.cpp
@@ -123,7 +123,7 @@ std::pair<CachedEntity *, Vector> FindBestEnt(bool teammate, bool Predict, bool 
         }
     }
     prevent = -1;
-    for (auto const &ent: entity_cache::player_cache)
+    for (auto const &ent : entity_cache::player_cache)
     {
         if (CE_BAD(ent) || !(ent->m_bAlivePlayer()) || (teammate && ent->m_iTeam() != LOCAL_E->m_iTeam()) || ent == LOCAL_E)
             continue;
@@ -312,9 +312,8 @@ static void SapperAimbot()
     CachedEntity *target = nullptr;
     float distance       = FLT_MAX;
 
-    for (int i = 32; i < entity_cache::max; ++i)
+    for (const auto &ent : entity_cache::valid_ents)
     {
-        CachedEntity* ent = ENTITY(i);
         if (CE_BAD(ent))
             continue;
         if (ent->m_Type() != ENTITY_BUILDING)
@@ -452,9 +451,9 @@ CachedEntity *targetBuilding(bool priority)
     float wrench_range   = re::C_TFWeaponBaseMelee::GetSwingRange(RAW_ENT(LOCAL_W));
     CachedEntity *target = nullptr;
     float distance       = FLT_MAX;
-    for (auto const &ent: entity_cache::valid_ents)
+    for (auto const &ent : entity_cache::valid_ents)
     {
-        
+
         // can't exactly repair Merasmus
         if (ent->m_Type() != ENTITY_BUILDING)
             continue;

--- a/src/hacks/NavBot.cpp
+++ b/src/hacks/NavBot.cpp
@@ -1563,7 +1563,7 @@ static void updateSlot(std::pair<CachedEntity *, float> &nearest)
     }
 }
 
-void CreateMove()
+static void CreateMove()
 {
     if (!enabled || !navparser::NavEngine::isReady())
         return;

--- a/src/hacks/Spam.cpp
+++ b/src/hacks/Spam.cpp
@@ -242,7 +242,7 @@ static std::vector<std::string> teamspam_text = { "CAT", "HOOK" };
 // Current spam index
 static size_t current_teamspam_idx = 0;
 
-void createMove()
+static void CreateMove()
 {
     IF_GAME(IsTF2())
     {
@@ -419,7 +419,7 @@ void teamspam_reload_command()
 }
 static InitRoutine EC([]() {
     teamname_file.installChangeCallback([](settings::VariableBase<std::string> &, std::string after) { teamspam_reload(after); });
-    EC::Register(EC::CreateMove, createMove, "spam", EC::average);
+    EC::Register(EC::CreateMove, CreateMove, "spam", EC::average);
     init();
 });
 

--- a/src/hacks/SpellForcer.cpp
+++ b/src/hacks/SpellForcer.cpp
@@ -150,7 +150,7 @@ CachedEntity *getClosestSpell()
     return ent;
 }
 
-void CreateMoveLate()
+static void CreateMoveLate()
 {
     if (!isEnabled() || !g_pGameRules->isUsingSpells_fn())
         return;

--- a/src/hacks/Trigger.cpp
+++ b/src/hacks/Trigger.cpp
@@ -50,7 +50,7 @@ inline float EffectiveTargetingRange()
         return *max_range;
 }
 // The main function of the triggerbot
-void CreateMove()
+static void CreateMove()
 {
     float backup_time = target_time;
     target_time       = 0;

--- a/src/hacks/Warp.cpp
+++ b/src/hacks/Warp.cpp
@@ -673,7 +673,7 @@ void CL_Move_hook(float accumulated_extra_samples, bool bFinalTick)
 
 // Run before we call the original, we need to adjust the tickcount on the command
 // and the global variable so our time based functions are synced properly.
-void CreateMoveEarly()
+static void CreateMoveEarly()
 {
     // Update key state
     key_valid = UpdateRFKey();
@@ -690,7 +690,7 @@ void CreateMoveEarly()
 static float original_curtime = 0.0f;
 
 // Run before prediction so we can do Faststop logic
-void CreateMovePrePredict()
+static void CreateMovePrePredict()
 {
     // Attempt to stop fast in place to make movement smoother
     if (in_rapidfire && no_movement)
@@ -715,12 +715,12 @@ void CreateMovePrePredict()
 
 // This calls the warp logic and applies some rapidfire specific logic afterwards
 // if it applies.
-void CreateMove()
+static void CreateMove()
 {
     warpLogic();
     if ((bool) hacks::tf2::warp::dodge_projectile && CE_GOOD(g_pLocalPlayer->entity))
         for (auto const &ent : entity_cache::valid_ents)
-            if ((*ent).m_Type() == ENTITY_PROJECTILE && (*ent).m_bEnemy() && std::find_if(proj_map.begin(), proj_map.end(), [=](const auto &item) { return std::get<1>(item) == ent; }) == proj_map.end())
+            if (ent->m_Type() == ENTITY_PROJECTILE && ent->m_bEnemy() && std::find_if(proj_map.begin(), proj_map.end(), [=](const auto &item) { return std::get<1>(item) == ent; }) == proj_map.end())
                 dodgeProj(ent);
     // Either in rapidfire, or the tick just after. Either way we need to force bSendPackets in some way.
     bool should_rapidfire = shouldRapidfire();

--- a/src/hacks/ac/aimbot.cpp
+++ b/src/hacks/ac/aimbot.cpp
@@ -54,7 +54,7 @@ void Update(CachedEntity *player)
         data.check_timer--;
         if (!data.check_timer)
         {
-            auto &angles      = angles::data(player);
+            auto &angles      = angles::data_[player->m_IDX];
             float deviation   = angles.deviation(2);
             int widx          = HandleToIDX(CE_INT(player, netvar.hActiveWeapon));
             CachedEntity *wep = ENTITY(widx);

--- a/src/hacks/ac/antiaim.cpp
+++ b/src/hacks/ac/antiaim.cpp
@@ -35,7 +35,7 @@ void Update(CachedEntity *player)
     auto &am = amount[player->m_IDX - 1];
     if (tickcount - last_accusation[player->m_IDX - 1] < 60 * 60)
         return;
-    const auto &d = angles::data(player);
+    const auto &d = angles::data_[player->m_IDX];
     if (d.angle_count)
     {
         int idx = d.angle_index - 1;

--- a/src/navparser.cpp
+++ b/src/navparser.cpp
@@ -862,7 +862,7 @@ void updateStuckTime()
     }
 }
 
-void CreateMove()
+static void CreateMove()
 {
     if (!isReady())
         return;

--- a/src/nospread.cpp
+++ b/src/nospread.cpp
@@ -68,7 +68,7 @@ bool shouldNoSpread(bool _projectile)
     return _projectile ? *projectile : *bullet;
 }
 
-void CreateMove()
+static void CreateMove()
 {
     if (CE_BAD(LOCAL_E) || CE_BAD(LOCAL_W))
         return;
@@ -832,7 +832,7 @@ void FX_FireBullets_hook(IClientEntity *weapon, int player, Vector *origin, Vect
 }*/
 
 static Timer update_nospread_timer{};
-void CreateMove2()
+static void CreateMove2()
 {
     if (bullet)
     {

--- a/src/projlogging.cpp
+++ b/src/projlogging.cpp
@@ -10,7 +10,7 @@
 
 namespace projectile_logging
 {
-Vector prevloc[2048]{};
+boost::unordered_flat_map<u_int16_t, Vector> prevloc;
 
 void Update()
 {


### PR DESCRIPTION
Changed vischeck, made it just check a centered hitbox instead of wasting time looping and checking. It's just used for visuals anyway. Changed the EC to use an actual function pointer instead of std::function, we use none of the features of std::function and it would be harder for the compiler to optimize for since it does type erasure and has additional overhead. Moved UpdateBones so that it only ever runs for actual players. 
Bugfixes:
Fixed Applyfiredelay, the sig was broken and was never caught
ControlPoint could crash if you attached while in the game since it could index out of bounds by one. 
