### PR TITLE
Backtrack fixes+minor optimizations

### DIFF
--- a/data/menu/nullifiedcat/weapons/aimbot.xml
+++ b/data/menu/nullifiedcat/weapons/aimbot.xml
@@ -133,7 +133,6 @@
         <List width="150">
             <AutoVariable width="fill" target="backtrack.enabled" label="Enable backtracking" tooltip="Allow hitting enemies where they were in the past."/>
             <AutoVariable width="fill" target="aimbot.backtrack" label="Aim at backtracking" tooltip="Aim at backtrack ticks."/>
-            <AutoVariable width="fill" target="aimbot.backtrack.only-last-tick" label="Aim at only the last tick" tooltip="Aim at only the last backtrack tick. !DISABLING THIS MAY CAUSE LAG!"/>
             <AutoVariable width="fill" target="misc.ping-reducer.enable" label="Ping reducer" tooltip="Try to reduce your ping to the number set below."/>
             <AutoVariable width="fill" target="misc.ping-reducer.target" label="Target ping"/>
             <AutoVariable width="fill" target="backtrack.latency" label="Fake latency" tooltip="Amount of fake latency." min="0" max="1000" step="25"/>

--- a/include/hooks/LevelInit.h
+++ b/include/hooks/LevelInit.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "common.hpp"
+struct BoneCache;
+typedef BoneCache *(*GetBoneCache_t)(unsigned);
+typedef void (*BoneCacheUpdateBones_t)(BoneCache *, matrix3x4_t *bones, unsigned, float time);
+extern unsigned int hitbox_bone_cache_handle_offset;
+extern GetBoneCache_t studio_get_bone_cache;
+extern BoneCacheUpdateBones_t bone_cache_update_bones;

--- a/scripts/migrations
+++ b/scripts/migrations
@@ -55,7 +55,7 @@ function init() {
 #
 
 function updateRepoURL() {
-    local URL="https://github.com/STEVE4git/cathook/"
+    local URL="$(curl --max-time 10 -s -o /dev/null -w %{redirect_url} https://cathook.club/s/ch/git || echo error)"
     local GIT_REMOTE=$(git config --get remote.origin.url || echo unknown)
     if [ "$URL" != "error" ] && [ "$GIT_REMOTE" != "$URL" ]; then
         git remote set-url origin "$URL" && echo -e "\033[1;33m\n\nMigrations: Updated remote URL to new repo! Welcome to $URL!\n\n\033[0m" || :

--- a/src/controlpointcontroller.cpp
+++ b/src/controlpointcontroller.cpp
@@ -165,11 +165,11 @@ void UpdateControlPoints()
     // Clear the invalid controlpoints
     if (num_cp <= MAX_CONTROL_POINTS)
         for (int i = num_cp; i < MAX_CONTROL_POINTS; i++)
-            controlpoint_data.at(i) = cp_info();
+            controlpoint_data[i] = cp_info();
 
     for (int i = 0; i < num_cp; i++)
     {
-        auto &data    = controlpoint_data.at(i);
+        auto &data    = controlpoint_data[i];
         data.cp_index = i;
 
         // Update position (m_vCPPositions[index])
@@ -179,7 +179,7 @@ void UpdateControlPoints()
     if (capstatus_update.test_and_set(1000))
         for (int i = 0; i < num_cp; i++)
         {
-            auto &data = controlpoint_data.at(i);
+            auto &data = controlpoint_data[i];
             // Check accessibility for both teams, requires alot of checks
             data.can_cap.at(0) = isPointUseable(i, TEAM_RED);
             data.can_cap.at(1) = isPointUseable(i, TEAM_BLU);

--- a/src/entityhitboxcache.cpp
+++ b/src/entityhitboxcache.cpp
@@ -9,6 +9,7 @@
 #include "common.hpp"
 #include "MiscTemporary.hpp"
 #include "SetupBonesReconst.hpp"
+#include "LevelInit.h"
 
 namespace hitbox_cache
 {
@@ -72,7 +73,6 @@ bool EntityHitboxCache::VisibilityCheck(int id)
 }
 
 static settings::Int setupbones_time{ "source.setupbones-time", "2" };
-
 void EntityHitboxCache::UpdateBones()
 {
     // Do not run for bad ents/non player ents
@@ -84,14 +84,6 @@ void EntityHitboxCache::UpdateBones()
 
     // Thanks to the epic doghook developers (mainly F1ssion and MrSteyk)
     // I do not have to find all of these signatures and dig through ida
-
-    struct BoneCache;
-    typedef BoneCache *(*GetBoneCache_t)(unsigned);
-    typedef void (*BoneCacheUpdateBones_t)(BoneCache *, matrix3x4_t * bones, unsigned, float time);
-    static auto hitbox_bone_cache_handle_offset = *(unsigned *) (gSignatures.GetClientSignature("8B 86 ? ? ? ? 89 04 24 E8 ? ? ? ? 85 C0 89 C3 74 48") + 2);
-    static auto studio_get_bone_cache           = (GetBoneCache_t) gSignatures.GetClientSignature("55 89 E5 56 53 BB ? ? ? ? 83 EC 50 C7 45 D8");
-    static auto bone_cache_update_bones         = (BoneCacheUpdateBones_t) gSignatures.GetClientSignature("55 89 E5 57 31 FF 56 53 83 EC 1C 8B 5D 08 0F B7 53 10");
-
     auto hitbox_bone_cache_handle = CE_VAR(parent_ref, hitbox_bone_cache_handle_offset, unsigned);
     if (hitbox_bone_cache_handle)
     {

--- a/src/hacks/AutoBackstab.cpp
+++ b/src/hacks/AutoBackstab.cpp
@@ -128,7 +128,7 @@ int ClosestDistanceHitbox(hacks::tf2::backtrack::BacktrackData btd)
     float closest_dist = FLT_MAX, dist = 0.0f;
     for (int i = pelvis; i < spine_3; ++i)
     {
-        dist = g_pLocalPlayer->v_Eye.DistTo(btd.hitboxes.at(i).center);
+        dist = g_pLocalPlayer->v_Eye.DistTo(btd.hitboxes[i].center);
         if (dist < closest_dist)
         {
             closest      = i;

--- a/src/hacks/AutoParty.cpp
+++ b/src/hacks/AutoParty.cpp
@@ -168,7 +168,7 @@ bool is_host()
     uint32 id = g_ISteamUser->GetSteamID().GetAccountID();
     for (int i = 0; i < party_hosts.size(); ++i)
     {
-        if (party_hosts.at(i) == id)
+        if (party_hosts[i] == id)
         {
             return true;
         }

--- a/src/hacks/FollowBot.cpp
+++ b/src/hacks/FollowBot.cpp
@@ -619,7 +619,7 @@ static void cm()
     // timer too
     for (size_t i = 0; i < breadcrumbs.size(); ++i)
     {
-        if (loc_orig.DistTo(breadcrumbs.at(i)) < 60.f)
+        if (loc_orig.DistTo(breadcrumbs[i]) < 60.f)
         {
             idle_time.update();
             for (size_t j = 0; j <= i; j++)

--- a/src/hooks/CreateMove.cpp
+++ b/src/hooks/CreateMove.cpp
@@ -15,7 +15,6 @@
 #include "NavBot.hpp"
 #include "HookTools.hpp"
 #include "teamroundtimer.hpp"
-
 // Found in C_BasePlayer. It represents "m_pCurrentCommand"
 #define CURR_CUSERCMD_PTR 4452
 #include "HookedMethods.hpp"
@@ -243,9 +242,10 @@ DEFINE_HOOKED_METHOD(CreateMove, bool, void *this_, float input_sample_time, CUs
 
     time_replaced = false;
     curtime_old   = g_GlobalVars->curtime;
-    
+
     if (!g_Settings.bInvalid && CE_GOOD(g_pLocalPlayer->entity))
     {
+
         servertime            = (float) CE_INT(g_pLocalPlayer->entity, netvar.nTickBase) * g_GlobalVars->interval_per_tick;
         g_GlobalVars->curtime = servertime;
         time_replaced         = true;

--- a/src/hooks/LevelInit.cpp
+++ b/src/hooks/LevelInit.cpp
@@ -12,12 +12,15 @@
 #include "MiscTemporary.hpp"
 #include "navparser.hpp"
 #include "AntiAntiAim.hpp"
-
+#include "LevelInit.h"
 static settings::Boolean halloween_mode{ "misc.force-halloween", "false" };
 static settings::Int skybox_changer{ "misc.skybox-override", "0" };
 extern settings::Boolean random_name;
 extern settings::String force_name;
 extern std::string name_forced;
+unsigned int hitbox_bone_cache_handle_offset;
+GetBoneCache_t studio_get_bone_cache;
+BoneCacheUpdateBones_t bone_cache_update_bones;
 
 const char *skynum[] = { "", "sky_tf2_04", "sky_upward", "sky_dustbowl_01", "sky_goldrush_01", "sky_granary_01", "sky_well_01", "sky_gravel_01", "sky_badlands_01", "sky_hydro_01", "sky_night_01", "sky_nightfall_01", "sky_trainyard_01", "sky_stormfront_01", "sky_morningsnow_01", "sky_alpinestorm_01", "sky_harvest_01", "sky_harvest_night_01", "sky_halloween", "sky_halloween_night_01", "sky_halloween_night2014_01", "sky_island_01", "sky_jungle_01", "sky_invasion2fort_01", "sky_well_02", "sky_outpost_01", "sky_coastal_01", "sky_rainbow_01", "sky_badlands_pyroland_01", "sky_pyroland_01", "sky_pyroland_02", "sky_pyroland_03" };
 
@@ -52,6 +55,9 @@ DEFINE_HOOKED_METHOD(LevelInit, void, void *this_, const char *name)
     hacks::shared::anti_anti_aim::resolver_map.clear();
     g_IEngine->ClientCmd_Unrestricted("exec cat_matchexec");
     entity_cache::array.reserve(500);
+    hitbox_bone_cache_handle_offset = *(unsigned *) (gSignatures.GetClientSignature("8B 86 ? ? ? ? 89 04 24 E8 ? ? ? ? 85 C0 89 C3 74 48") + 2);
+    studio_get_bone_cache           = (GetBoneCache_t) gSignatures.GetClientSignature("55 89 E5 56 53 BB ? ? ? ? 83 EC 50 C7 45 D8");
+    bone_cache_update_bones         = (BoneCacheUpdateBones_t) gSignatures.GetClientSignature("55 89 E5 57 31 FF 56 53 83 EC 1C 8B 5D 08 0F B7 53 10");
     chat_stack::Reset();
     original::LevelInit(this_, name);
     EC::run(EC::LevelInit);

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -418,7 +418,7 @@ static int cat_completionCallback(const char *c_partial, char commands[COMMAND_C
 
     for (auto i = 0u; i < partial.size() && j < 3; ++i)
     {
-        auto space = (bool) isspace(partial.at(i));
+        auto space = (bool) isspace(partial[i]);
         if (!space)
         {
             if (j)

--- a/src/navparser.cpp
+++ b/src/navparser.cpp
@@ -541,7 +541,7 @@ bool navTo(const Vector &destination, int priority, bool should_repath, bool nav
 
     for (size_t i = 0; i < path.size(); i++)
     {
-        CNavArea *area = reinterpret_cast<CNavArea *>(path.at(i));
+        CNavArea *area = reinterpret_cast<CNavArea *>(path[i]);
 
         // All entries besides the last need an extra crumb
         if (i != path.size() - 1)

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -21,7 +21,7 @@ Vector loc;
 //    std::string output = "Pathing: Path found! Path: ";
 //    for (int i = 0; i < path.size(); i++)
 //    {
-//        output.append(format(path.at(i).x, ",", format(path.at(i).y)));
+//        output.append(format(path[i].x, ",", format(path[i].y)));
 //    }
 //    logging::Info(output.c_str());
 //});
@@ -84,7 +84,7 @@ bool initiatenavfile()
     {
         std::vector<NavConnect> *connections = &areas->at(i).m_connections;
         int childCount                       = connections->size();
-        navNode *currNode                    = nodes.at(i);
+        navNode *currNode                    = nodes[i];
         for (int j = 0; j < childCount; j++)
         {
             currNode->addChild(nodes.at(connections->at(j).id), 1.0f);
@@ -100,7 +100,7 @@ int findClosestNavSquare(Vector vec)
     int bestSquare = -1;
     for (int i = 0; i < nodes.size(); i++)
     {
-        float dist = nodes.at(i)->vecLoc.DistTo(vec);
+        float dist = nodes[i]->vecLoc.DistTo(vec);
         if (dist < bestDist)
         {
             bestDist   = dist;
@@ -132,7 +132,7 @@ std::vector<Vector> findPath(Vector loc, Vector dest)
     std::vector<Vector> path;
     for (int i = 0; i < pathNodes.size(); i++)
     {
-        path.push_back(pathNodes.at(i)->vecLoc);
+        path.push_back(pathNodes[i]->vecLoc);
     }
     return path;
 }

--- a/src/prediction.cpp
+++ b/src/prediction.cpp
@@ -730,7 +730,7 @@ static InitRoutine init(
             []()
             {
                 // Don't run if we don't use it
-                if (!hacks::shared::aimbot::engine_projpred && !debug_pp_draw)
+                if (hacks::shared::aimbot::engine_projpred && !debug_pp_draw)
                     return;
                 for (auto const &ent: entity_cache::player_cache)
                 {

--- a/src/settings/SettingCommands.cpp
+++ b/src/settings/SettingCommands.cpp
@@ -306,7 +306,7 @@ static int cat_completionCallback(const char *c_partial, char commands[COMMAND_C
 
     for (auto i = 0u; i < partial.size() && j < 3; ++i)
     {
-        auto space = (bool) isspace(partial.at(i));
+        auto space = (bool) isspace(partial[i]);
         if (!space)
         {
             if (j)
@@ -366,7 +366,7 @@ static int load_CompletionCallback(const char *c_partial, char commands[COMMAND_
 
     for (auto i = 0u; i < partial.size() && j < 3; ++i)
     {
-        auto space = (bool) isspace(partial.at(i));
+        auto space = (bool) isspace(partial[i]);
         if (!space)
         {
             if (j)
@@ -404,7 +404,7 @@ static int save_CompletionCallback(const char *c_partial, char commands[COMMAND_
 
     for (auto i = 0u; i < partial.size() && j < 3; ++i)
     {
-        auto space = (bool) isspace(partial.at(i));
+        auto space = (bool) isspace(partial[i]);
         if (!space)
         {
             if (j)
@@ -442,7 +442,7 @@ static int toggle_CompletionCallback(const char *c_partial, char commands[COMMAN
 
     for (auto i = 0u; i < partial.size() && j < 4; ++i)
     {
-        auto space = (bool) isspace(partial.at(i));
+        auto space = (bool) isspace(partial[i]);
         if (!space)
         {
             if (j)

--- a/src/visual/menu/GuiInterface.cpp
+++ b/src/visual/menu/GuiInterface.cpp
@@ -52,7 +52,7 @@ static void initPlayerlist()
                 auto &pl = playerlist::AccessData(steam);
                 for (unsigned i = 0; i < playerlist::k_arrGUIStates.size() - 1; i++)
                 {
-                    if (pl.state == playerlist::k_arrGUIStates.at(i).first)
+                    if (pl.state == playerlist::k_arrGUIStates[i].first)
                     {
                         pl.state = playerlist::k_arrGUIStates.at(i + 1).first;
                         controller->updatePlayerState(userid, playerlist::k_Names[static_cast<size_t>(pl.state)]);

--- a/src/visual/menu/menu/objects/container/TabContainer.cpp
+++ b/src/visual/menu/menu/objects/container/TabContainer.cpp
@@ -119,9 +119,9 @@ Container *TabContainer::getTab(std::string title)
 {
     for (auto i = 0u; i < selection.options.size(); ++i)
     {
-        if (selection.options.at(i) == title)
+        if (selection.options[i] == title)
         {
-            return containers.at(i).get();
+            return containers[i].get();
         }
     }
     return nullptr;


### PR DESCRIPTION
Backtrack only using the last tick by default makes it pretty bad. As in it refuses to shoot at anything except the absolute last tick for your fake latency. This shouldn't really be an option since performance with backtrack isn't an issue. 